### PR TITLE
[#12] Coordinator 설계 및 세팅

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,18 @@
 		ECA425CF292382AD004DFDAF /* NavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425CE292382AD004DFDAF /* NavigationView.swift */; };
 		ECA425D52924D95C004DFDAF /* GoogleMap.plist in Resources */ = {isa = PBXBuildFile; fileRef = ECA425D42924D95C004DFDAF /* GoogleMap.plist */; };
 		ECA425D72924DA66004DFDAF /* Bundle + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425D62924DA66004DFDAF /* Bundle + Extension.swift */; };
+		ECA425DA29253155004DFDAF /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425D929253155004DFDAF /* Coordinator.swift */; };
+		ECA425DC29253259004DFDAF /* CoordinatorFinishDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425DB29253259004DFDAF /* CoordinatorFinishDelegate.swift */; };
+		ECA425DE29253292004DFDAF /* CoordinatorCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425DD29253292004DFDAF /* CoordinatorCase.swift */; };
+		ECA425E0292532B7004DFDAF /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425DF292532B7004DFDAF /* AppCoordinator.swift */; };
+		ECA425E2292532CA004DFDAF /* ImplAppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425E1292532CA004DFDAF /* ImplAppCoordinator.swift */; };
+		ECA425E429262A37004DFDAF /* ImplMapCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425E329262A37004DFDAF /* ImplMapCoordinator.swift */; };
+		ECA425E629262A42004DFDAF /* ImplLoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425E529262A42004DFDAF /* ImplLoginCoordinator.swift */; };
+		ECA425E829262A78004DFDAF /* MapCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425E729262A78004DFDAF /* MapCoordinator.swift */; };
+		ECA425EA29262A80004DFDAF /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425E929262A80004DFDAF /* LoginCoordinator.swift */; };
+		ECA425EC29262CF8004DFDAF /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425EB29262CF7004DFDAF /* MapViewModel.swift */; };
+		ECA425F4292634A6004DFDAF /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425F3292634A5004DFDAF /* LoginViewController.swift */; };
+		ECA425F6292634C9004DFDAF /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA425F5292634C9004DFDAF /* LoginViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +116,18 @@
 		ECA425CE292382AD004DFDAF /* NavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationView.swift; sourceTree = "<group>"; };
 		ECA425D42924D95C004DFDAF /* GoogleMap.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
 		ECA425D62924DA66004DFDAF /* Bundle + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle + Extension.swift"; sourceTree = "<group>"; };
+		ECA425D929253155004DFDAF /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		ECA425DB29253259004DFDAF /* CoordinatorFinishDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFinishDelegate.swift; sourceTree = "<group>"; };
+		ECA425DD29253292004DFDAF /* CoordinatorCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorCase.swift; sourceTree = "<group>"; };
+		ECA425DF292532B7004DFDAF /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		ECA425E1292532CA004DFDAF /* ImplAppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplAppCoordinator.swift; sourceTree = "<group>"; };
+		ECA425E329262A37004DFDAF /* ImplMapCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplMapCoordinator.swift; sourceTree = "<group>"; };
+		ECA425E529262A42004DFDAF /* ImplLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplLoginCoordinator.swift; sourceTree = "<group>"; };
+		ECA425E729262A78004DFDAF /* MapCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapCoordinator.swift; sourceTree = "<group>"; };
+		ECA425E929262A80004DFDAF /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
+		ECA425EB29262CF7004DFDAF /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		ECA425F3292634A5004DFDAF /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		ECA425F5292634C9004DFDAF /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -237,7 +261,9 @@
 		ECA4255F2922528B004DFDAF /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				ECA425F229263495004DFDAF /* Common */,
 				ECA425672922533A004DFDAF /* Splash */,
+				ECA425F129263486004DFDAF /* Login */,
 				ECA4256A29225355004DFDAF /* Map */,
 				ECA425692922534E004DFDAF /* BottomDetailView */,
 				ECA4256829225346004DFDAF /* SideBar */,
@@ -268,6 +294,7 @@
 		ECA42562292252AB004DFDAF /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				ECA425F029263461004DFDAF /* Contstant */,
 				ECA42563292252BC004DFDAF /* Base */,
 				ECA42565292252E7004DFDAF /* Logging */,
 				ECA4256629225303004DFDAF /* UIComponents */,
@@ -336,8 +363,10 @@
 		ECA4256A29225355004DFDAF /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				ECA425F929263562004DFDAF /* Coordinator */,
 				ECA425772922545C004DFDAF /* MapViewController.swift */,
 				ECA425CE292382AD004DFDAF /* NavigationView.swift */,
+				ECA425EB29262CF7004DFDAF /* MapViewModel.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -384,6 +413,93 @@
 				ECA425D62924DA66004DFDAF /* Bundle + Extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		ECA425ED292633FA004DFDAF /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425E1292532CA004DFDAF /* ImplAppCoordinator.swift */,
+				ECA425EF29263439004DFDAF /* Delegate */,
+				ECA425EE29263428004DFDAF /* Protocol */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		ECA425EE29263428004DFDAF /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425DF292532B7004DFDAF /* AppCoordinator.swift */,
+				ECA425D929253155004DFDAF /* Coordinator.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		ECA425EF29263439004DFDAF /* Delegate */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425DB29253259004DFDAF /* CoordinatorFinishDelegate.swift */,
+			);
+			path = Delegate;
+			sourceTree = "<group>";
+		};
+		ECA425F029263461004DFDAF /* Contstant */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425DD29253292004DFDAF /* CoordinatorCase.swift */,
+			);
+			path = Contstant;
+			sourceTree = "<group>";
+		};
+		ECA425F129263486004DFDAF /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425F729263537004DFDAF /* Coordinator */,
+				ECA425F3292634A5004DFDAF /* LoginViewController.swift */,
+				ECA425F5292634C9004DFDAF /* LoginViewModel.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		ECA425F229263495004DFDAF /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425ED292633FA004DFDAF /* Coordinator */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		ECA425F729263537004DFDAF /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425E529262A42004DFDAF /* ImplLoginCoordinator.swift */,
+				ECA425F829263548004DFDAF /* Protocol */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		ECA425F829263548004DFDAF /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425E929262A80004DFDAF /* LoginCoordinator.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		ECA425F929263562004DFDAF /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425E329262A37004DFDAF /* ImplMapCoordinator.swift */,
+				ECA425FA29263567004DFDAF /* Protocol */,
+			);
+			path = Coordinator;
+			sourceTree = "<group>";
+		};
+		ECA425FA29263567004DFDAF /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				ECA425E729262A78004DFDAF /* MapCoordinator.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -646,16 +762,28 @@
 			files = (
 				ECA4259929229BD9004DFDAF /* UIFont + Extension.swift in Sources */,
 				ECA4257629225450004DFDAF /* SplashViewController.swift in Sources */,
+				ECA425DA29253155004DFDAF /* Coordinator.swift in Sources */,
+				ECA425F4292634A6004DFDAF /* LoginViewController.swift in Sources */,
 				ECA425CF292382AD004DFDAF /* NavigationView.swift in Sources */,
+				ECA425E0292532B7004DFDAF /* AppCoordinator.swift in Sources */,
+				ECA425E629262A42004DFDAF /* ImplLoginCoordinator.swift in Sources */,
+				ECA425DC29253259004DFDAF /* CoordinatorFinishDelegate.swift in Sources */,
 				ECA4257C292254B0004DFDAF /* SideBarViewController.swift in Sources */,
 				ECA4252D29224DB8004DFDAF /* AppDelegate.swift in Sources */,
+				ECA425EA29262A80004DFDAF /* LoginCoordinator.swift in Sources */,
+				ECA425DE29253292004DFDAF /* CoordinatorCase.swift in Sources */,
+				ECA425F6292634C9004DFDAF /* LoginViewModel.swift in Sources */,
 				ECA4259729229B15004DFDAF /* FogFont.swift in Sources */,
 				ECA4257A292254A8004DFDAF /* BottomDetailViewController.swift in Sources */,
 				ECA4259B2922A4A6004DFDAF /* FogImage.swift in Sources */,
+				ECA425E829262A78004DFDAF /* MapCoordinator.swift in Sources */,
+				ECA425E2292532CA004DFDAF /* ImplAppCoordinator.swift in Sources */,
 				ECA4252F29224DB8004DFDAF /* SceneDelegate.swift in Sources */,
+				ECA425EC29262CF8004DFDAF /* MapViewModel.swift in Sources */,
 				ECA4257E292254C6004DFDAF /* BaseViewController.swift in Sources */,
 				ECA425782922545C004DFDAF /* MapViewController.swift in Sources */,
 				ECA425D72924DA66004DFDAF /* Bundle + Extension.swift in Sources */,
+				ECA425E429262A37004DFDAF /* ImplMapCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FogFog-iOS/FogFog-iOS/App/SceneDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/App/SceneDelegate.swift
@@ -10,13 +10,16 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    var appCoordinator: AppCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        window = UIWindow(windowScene: windowScene)
-        window?.windowScene = windowScene
-        window?.rootViewController = UINavigationController(rootViewController: SplashViewController())
-        window?.makeKeyAndVisible()
+        let navigationController = UINavigationController()
+        self.appCoordinator = ImplAppCoordinator(navigationController)
+        self.appCoordinator?.start()
+        self.window = UIWindow(windowScene: windowScene)
+        self.window?.rootViewController = navigationController
+        self.window?.makeKeyAndVisible()
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Delegate/CoordinatorFinishDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Delegate/CoordinatorFinishDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  CoordinatorFinishDelegate.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/16.
+//
+
+import Foundation
+
+protocol CoordinatorFinishDelegate: AnyObject {
+
+    func didFinish(childCoordinator: Coordinator)
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/ImplAppCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/ImplAppCoordinator.swift
@@ -1,0 +1,65 @@
+//
+//  ImplAppCoordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import UIKit
+
+final class ImplAppCoordinator: AppCoordinator {
+
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var childCoordinators = [Coordinator]()
+    var type: CoordinatorCase { .app }
+
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+        
+        // BaseViewController에서 ViewWillAppear에 해당하는 부분인데
+        // BaseViewController에서 코드를 지울지, 아래의 코드를 지울지 논의 필요
+        navigationController.setNavigationBarHidden(true, animated: true)
+    }
+    
+    func start() {
+        /// 토큰이 UserDefaults에 저장되어 있을 때, 앱의 시작점을 mapFlow로 아니면 loginFlow로
+        /// UserDefaultsManager.token.isEmpty ? showLoginFlow() : showMapFlow()
+        /// 일단 MapViewController로 연결
+        showMapFlow()
+    }
+    
+    func showLoginFlow() {
+        
+        let loginCoordinator = ImplLoginCoordinator(self.navigationController)
+        loginCoordinator.finishDelegate = self
+        loginCoordinator.start()
+        childCoordinators.append(loginCoordinator)
+    }
+    
+    func showMapFlow() {
+        
+        let mapCoordinator = ImplMapCoordinator(self.navigationController)
+        mapCoordinator.finishDelegate = self
+        mapCoordinator.start()
+        childCoordinators.append(mapCoordinator)
+    }
+}
+
+extension ImplAppCoordinator: CoordinatorFinishDelegate {
+
+    func didFinish(childCoordinator: Coordinator) {
+        
+        self.childCoordinators = self.childCoordinators.filter({ $0.type != childCoordinator.type })
+        self.navigationController.viewControllers.removeAll()
+        
+        switch childCoordinator.type {
+        case .login:
+            self.showMapFlow()
+        case .map:
+            self.showLoginFlow()
+        default:
+            break
+        }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/ImplAppCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/ImplAppCoordinator.swift
@@ -23,9 +23,11 @@ final class ImplAppCoordinator: AppCoordinator {
     }
     
     func start() {
+        
         /// 토큰이 UserDefaults에 저장되어 있을 때, 앱의 시작점을 mapFlow로 아니면 loginFlow로
         /// UserDefaultsManager.token.isEmpty ? showLoginFlow() : showMapFlow()
         /// 일단 MapViewController로 연결
+        
         showMapFlow()
     }
     

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Protocol/AppCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Protocol/AppCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  AppCoordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import Foundation
+
+protocol AppCoordinator: Coordinator {
+    
+    func showLoginFlow()
+    func showMapFlow()
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Protocol/Coordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Protocol/Coordinator.swift
@@ -1,0 +1,45 @@
+//
+//  Coordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/16.
+//
+
+import UIKit
+
+protocol Coordinator: AnyObject {
+
+    var finishDelegate: CoordinatorFinishDelegate? { get set }
+    var navigationController: UINavigationController { get set }
+    var childCoordinators: [Coordinator] { get set }
+    var type: CoordinatorCase { get }
+    func start()
+    func finish()
+
+    init(_ navigationController: UINavigationController)
+}
+
+extension Coordinator {
+
+    func finish() {
+        
+        childCoordinators.removeAll()
+        finishDelegate?
+            .didFinish(childCoordinator: self)
+    }
+
+    func changeAnimation() {
+        
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first as? UIWindowScene
+        let window = windowScene?.windows.first
+        
+        if let window = window {
+            UIView.transition(with: window,
+                              duration: 0.5,
+                              options: .transitionCrossDissolve,
+                              animations: nil)
+        }
+    }
+}
+

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/ImplLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/ImplLoginCoordinator.swift
@@ -1,0 +1,42 @@
+//
+//  ImplLoginCoordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import UIKit
+
+final class ImplLoginCoordinator: LoginCoordinator {
+    
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var childCoordinators = [Coordinator]()
+    var type: CoordinatorCase { .login }
+    
+    init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        
+        showLoginViewController()
+    }
+    
+    func showLoginViewController() {
+        
+    }
+    
+    func connectMapCoordinator() {
+        
+        let mapCoordinator = ImplMapCoordinator(self.navigationController)
+        mapCoordinator.start()
+        self.childCoordinators.append(mapCoordinator)
+    }
+    
+    func finish() {
+        
+        finishDelegate?
+            .didFinish(childCoordinator: self)
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/Protocol/LoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/Protocol/LoginCoordinator.swift
@@ -1,0 +1,14 @@
+//
+//  LoginCoordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import Foundation
+
+protocol LoginCoordinator: Coordinator {
+    
+    func showLoginViewController()
+    func connectMapCoordinator()
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/LoginViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/LoginViewController.swift
@@ -1,0 +1,26 @@
+//
+//  LoginViewController.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import UIKit
+
+final class LoginViewController: BaseViewController {
+    
+    private weak var viewModel: LoginViewModel?
+    
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("MapViewController Error!")
+    }
+    
+    override func viewDidLoad() {
+        
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/LoginViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/LoginViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  LoginViewModel.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import UIKit
+
+final class LoginViewModel {
+    
+    private weak var coordinator: LoginCoordinator?
+    
+    init(coordinator: LoginCoordinator?) {
+        self.coordinator = coordinator
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/ImplMapCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/ImplMapCoordinator.swift
@@ -1,0 +1,39 @@
+//
+//  ImplMapCoordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import UIKit
+
+final class ImplMapCoordinator: MapCoordinator {
+ 
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    var navigationController: UINavigationController
+    var childCoordinators = [Coordinator]()
+    var type: CoordinatorCase { .map }
+
+    init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        
+        showMapViewController()
+    }
+
+    func showMapViewController() {
+        
+        let mapViewModel = MapViewModel(coordinator: self)
+        let mapViewController = MapViewController(viewModel: mapViewModel)
+        changeAnimation()
+        navigationController.viewControllers = [mapViewController]
+    }
+    
+    func finish() {
+        
+        finishDelegate?
+            .didFinish(childCoordinator: self)
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/Protocol/MapCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/Protocol/MapCoordinator.swift
@@ -1,0 +1,13 @@
+//
+//  MapCoordinator.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import Foundation
+
+protocol MapCoordinator: Coordinator {
+    
+    func showMapViewController()
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -21,6 +21,17 @@ final class MapViewController: BaseViewController {
     private var locationManager = CLLocationManager()
     private var currentLocation: CLLocation!
     
+    private weak var viewModel: MapViewModel?
+    
+    init(viewModel: MapViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("MapViewController Error!")
+    }
+    
     override func loadView() {
         self.view = mapView
     }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  MapViewModel.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import UIKit
+
+final class MapViewModel {
+    
+    private weak var coordinator: MapCoordinator?
+    
+    init(coordinator: MapCoordinator?) {
+        self.coordinator = coordinator
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Utils/Contstant/CoordinatorCase.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Contstant/CoordinatorCase.swift
@@ -1,0 +1,14 @@
+//
+//  CoordinatorCase.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2022/11/17.
+//
+
+import Foundation
+
+enum CoordinatorCase {
+    case app
+    case login
+    case map
+}


### PR DESCRIPTION
## 🔍 What is this PR?
- Coordinator 설계 및 세팅

## 논의사항
- Coordinator 파일들의 위치 및 폴더링
- Coordinator 설계 기준은 화면 전환이 여러번 이어질 때 추가를 해도 좋다는 생각
   - MapCoordinator에서 시작한 SideBarCoordinator, SettingCoordinator 는 안에서 화면 전환이 두개 이상 이루어지므로 만들어도 괜찮다는 생각
   - BottomSheet에서는 당장 dismiss 밖에 없을 것 같아서 MapCoordinator를 사용해도 괜찮을 것 같다는 생각
   - 다만 업데이트 과정에서 화면전환이 더 생긴다면 그떄 새로 만들어도 될 것 같음! 
   - 좋은 아이디어 있으면 의견주세요 !!!

## 📸 Screenshot

<img src = "https://user-images.githubusercontent.com/80672561/202478032-537a63ca-32b6-4ef0-b98c-e8409b2efd70.jpeg"  height = "400"/>

![스크린샷 2022-11-18 오전 12 01 24](https://user-images.githubusercontent.com/80672561/202481192-6fa3b9a4-bd3b-43e2-80d8-06bec4a5e8f9.png)

## finishDelegate
- 작업을 모두 마쳤을 떄, 이를테면 해당 코디네이터가 더이상 필요가 없을 때, 다른 코디네이터가 start() 할 수 있게 만든 델리게이트
- 예를 들어 LoginFlow가 끝났을 때 MapFlow 시작할 수 있도록 함

## navigationController
- 코디네이터에서 사용할 navigationController, 코디네이터에서 처리하는 모든 뷰 컨트롤러는 이 navigationController가 삽입

## childCoordinators
- Coordinator 인스턴스의 배열로 이 코디네이터의 하위에 들어갈 코디네이터들의 목록을 의미
- AppCoordinator의 childCoordinators는 [LoginCoordinator, MapCoordinator]

## type
- enum으로 만들었고 나중에 특정한 코디네이터를 찾을 때 키값으로 사용될 예정
- 현재는 ImplAppCoordinator에서 사용 

## start, finish
- 코디네이터의 시작과 종료를 의미

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #12
