### PR TITLE
[#39] 애플 로그인 구현

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		BD90E9DD2976C11E00C7CB6B /* FogAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogAPI.swift; sourceTree = "<group>"; };
 		BD90E9DF2976C3EF00C7CB6B /* NetworkEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEnv.swift; sourceTree = "<group>"; };
 		BD90E9E12976C4F800C7CB6B /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "FogFog-iOS.entitlements"; sourceTree = "<group>"; };
 		BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		BDC20F9C293B44B600B9A2E7 /* FogToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogToast.swift; sourceTree = "<group>"; };
 		BDC50ECA292A07B2002378C6 /* GoogleMap.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
@@ -479,6 +480,7 @@
 		ECA4252B29224DB8004DFDAF /* FogFog-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */,
 				ECA4255D292251D8004DFDAF /* App */,
 				ECA4255E292251E0004DFDAF /* Models */,
 				BD4E13632973DAA300AEA757 /* Networking */,
@@ -1296,10 +1298,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "FogFog-iOS/FogFog-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 397WA8BG8W;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FogFog-iOS/Supports/Info.plist";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 체크";
@@ -1329,10 +1332,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "FogFog-iOS/FogFog-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 397WA8BG8W;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FogFog-iOS/Supports/Info.plist";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 체크";

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -1314,7 +1314,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 397WA8BG8W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FogFog-iOS/Supports/Info.plist";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 체크";
@@ -1348,7 +1348,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 397WA8BG8W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FogFog-iOS/Supports/Info.plist";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 체크";

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		BD90E9DE2976C11E00C7CB6B /* FogAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD90E9DD2976C11E00C7CB6B /* FogAPI.swift */; };
 		BD90E9E02976C3EF00C7CB6B /* NetworkEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD90E9DF2976C3EF00C7CB6B /* NetworkEnv.swift */; };
 		BD90E9E22976C4F800C7CB6B /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD90E9E12976C4F800C7CB6B /* Networking.swift */; };
+		BD9AA41829929ABD00D4E7CE /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */; };
 		BDC20F9A293B446D00B9A2E7 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */; };
 		BDC20F9D293B44B600B9A2E7 /* FogToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F9C293B44B600B9A2E7 /* FogToast.swift */; };
 		BDC50ECB292A07B2002378C6 /* GoogleMap.plist in Resources */ = {isa = PBXBuildFile; fileRef = BDC50ECA292A07B2002378C6 /* GoogleMap.plist */; };
@@ -160,6 +161,7 @@
 		BD90E9DF2976C3EF00C7CB6B /* NetworkEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkEnv.swift; sourceTree = "<group>"; };
 		BD90E9E12976C4F800C7CB6B /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "FogFog-iOS.entitlements"; sourceTree = "<group>"; };
+		BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		BDC20F9C293B44B600B9A2E7 /* FogToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogToast.swift; sourceTree = "<group>"; };
 		BDC50ECA292A07B2002378C6 /* GoogleMap.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
@@ -396,6 +398,14 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
+		BD9AA41629929AB200D4E7CE /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
 		BDB152C0297E6834002E477F /* APIs */ = {
 			isa = PBXGroup;
 			children = (
@@ -481,6 +491,7 @@
 			isa = PBXGroup;
 			children = (
 				BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */,
+				BD9AA41629929AB200D4E7CE /* Manager */,
 				ECA4255D292251D8004DFDAF /* App */,
 				ECA4255E292251E0004DFDAF /* Models */,
 				BD4E13632973DAA300AEA757 /* Networking */,
@@ -1090,6 +1101,7 @@
 				ECA4252D29224DB8004DFDAF /* AppDelegate.swift in Sources */,
 				ECA425EA29262A80004DFDAF /* LoginCoordinator.swift in Sources */,
 				ECA425DE29253292004DFDAF /* CoordinatorCase.swift in Sources */,
+				BD9AA41829929ABD00D4E7CE /* AppleLoginManager.swift in Sources */,
 				BD90E9E02976C3EF00C7CB6B /* NetworkEnv.swift in Sources */,
 				BD46305C292A25B300E9E9C2 /* BottomDetailRootView.swift in Sources */,
 				BD4B550F292A29EC00ECFD04 /* SmokePlace.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/FogFog-iOS.entitlements
+++ b/FogFog-iOS/FogFog-iOS/FogFog-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/FogFog-iOS/FogFog-iOS/Manager/AppleLoginManager.swift
+++ b/FogFog-iOS/FogFog-iOS/Manager/AppleLoginManager.swift
@@ -1,0 +1,116 @@
+//
+//  AppleLoginManager.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/02/07.
+//
+
+import AuthenticationServices
+
+/// AppleUser
+///
+/// - id: 애플 idToken(로그인/회원가입 시 사용)
+/// - email: 이메일
+/// - origin: 애플 원본 Credential
+struct AppleUser {
+    var id: String
+    var email: String
+    var origin: Any
+    
+    init(credential: ASAuthorizationAppleIDCredential) {
+        self.id = credential.user
+        self.email = credential.email ?? ""
+        self.origin = credential
+    }
+}
+
+/// 애플 로그인 매니저
+final class AppleLoginManager: NSObject {
+    
+    // 클래스 간 순환 참조 방지
+    private weak var viewController: UIViewController?
+    var loggedIn: ((_ status: Bool, _ message: String, _ user: AppleUser?) -> Void)?
+    
+    override init() {
+        super.init()
+    }
+    
+    convenience init(from viewController: UIViewController) {
+        self.init()
+        self.viewController = viewController
+    }
+    
+    convenience init(with button: UIButton, from viewController: UIViewController) {
+        self.init()
+        button.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
+        self.viewController = viewController
+    }
+    
+    // 로그인 버튼 클릭 시 로직 수행
+    @objc func handleAuthorizationAppleIDButtonPress() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+    
+    // 애플 로그인 상태 확인
+    static func getCredentialState(completion: ((ASAuthorizationAppleIDProvider.CredentialState) -> Void)? = nil) {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        
+        // TODO: 이후에 UserID 가져와서 체크
+        appleIDProvider.getCredentialState(forUserID: "") { (credentialState, error) in
+            switch credentialState {
+            case .authorized:
+                print("The Apple ID credential is valid.")
+                break
+            
+            case .revoked:
+                print("The Apple ID credential is revoked. need logout progress.")
+                completion?(credentialState)
+                break
+                
+            case .notFound:
+                print("User identifier value is wrong or Apple login system has a problem.")
+                completion?(credentialState)
+                break
+            default:
+                break
+            }
+        }
+    }
+}
+
+// MARK: ASAuthorizationControllerDelegate
+extension AppleLoginManager: ASAuthorizationControllerDelegate {
+    
+    // Apple 로그인 성공
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        switch authorization.credential {
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            let appleUser = AppleUser(credential: appleIDCredential)
+            loggedIn?(true, "", appleUser)
+            
+        default:
+            loggedIn?(false, "Apple credential is not found", nil)
+        }
+    }
+    
+    // Apple 로그인 실패
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        loggedIn?(false, error.localizedDescription, nil)
+    }
+}
+
+// MARK: ASWebAuthenticationPresentationContextProviding
+extension AppleLoginManager: ASAuthorizationControllerPresentationContextProviding {
+    
+    // Apple 로그인 모달 시트
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return viewController!.view.window!
+    }
+}


### PR DESCRIPTION
## 🔍 What is this PR?
Apple Login Manager 구현

## 📝 Changes
- 애플 로그인 역할/책임 담당하는 Manager 클래스 구현
- handleAuthorizationAppleIDButtonPress 메서드로 애플 서버로 로그인 Request가 수행되고, 이후 성공 또는 실패 여부에 따라 유저 정보를 받아오거나 에러메시지를 loggedIn이라는 클로저로 넘겨줍니다.
- 음 생각해보니까 Rx로 Wrapping하는 방식으로 리팩토링 한 번 하면 좋을 것 같습니다. (일단 기능상으로 문제는 없어서 현상 유지 하겠습니다.)

## 📸 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## ☑️ Test Checklist

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #39