### PR TITLE
[#42] 닉네임 조회 API 연결

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */; };
 		77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */; };
 		77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */; };
-		77CB027829D02863006817E5 /* NicknameResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027729D02863006817E5 /* NicknameResModel.swift */; };
+		77CB027829D02863006817E5 /* NicknameResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027729D02863006817E5 /* NicknameResponseModel.swift */; };
 		77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027A29D02FA1006817E5 /* UserAPIService.swift */; };
 		77CB027F29DEAE57006817E5 /* RxMoya + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */; };
 		77D32D41292A0EDD006E6314 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D40292A0EDD006E6314 /* ViewModelType.swift */; };
@@ -137,7 +137,7 @@
 		776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTitleTableViewCell.swift; sourceTree = "<group>"; };
 		77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
-		77CB027729D02863006817E5 /* NicknameResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameResModel.swift; sourceTree = "<group>"; };
+		77CB027729D02863006817E5 /* NicknameResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameResponseModel.swift; sourceTree = "<group>"; };
 		77CB027A29D02FA1006817E5 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
 		77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxMoya + Extension.swift"; sourceTree = "<group>"; };
 		77D32D40292A0EDD006E6314 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
@@ -434,7 +434,7 @@
 			isa = PBXGroup;
 			children = (
 				BD90E9DB2976C02100C7CB6B /* CommonResponse.swift */,
-				77CB027729D02863006817E5 /* NicknameResModel.swift */,
+				77CB027729D02863006817E5 /* NicknameResponseModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1153,7 +1153,7 @@
 				BD347C60292FD4C8009F52BA /* FogButton.swift in Sources */,
 				ECA4257E292254C6004DFDAF /* BaseViewController.swift in Sources */,
 				BDC20F9A293B446D00B9A2E7 /* SplashViewController.swift in Sources */,
-				77CB027829D02863006817E5 /* NicknameResModel.swift in Sources */,
+				77CB027829D02863006817E5 /* NicknameResponseModel.swift in Sources */,
 				7761D4F6292F3749003971DC /* FogNavigationView.swift in Sources */,
 				77650202295448AE002BF7AD /* SettingViewController.swift in Sources */,
 				77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */; };
 		77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */; };
 		77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */; };
+		77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027A29D02FA1006817E5 /* UserAPIService.swift */; };
 		77D32D41292A0EDD006E6314 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D40292A0EDD006E6314 /* ViewModelType.swift */; };
 		77D32D43292CD6A3006E6314 /* SideBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D42292CD6A2006E6314 /* SideBarView.swift */; };
 		77E70F462930951100F55CD7 /* UITextField + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E70F452930951100F55CD7 /* UITextField + Extension.swift */; };
@@ -134,6 +135,7 @@
 		776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTitleTableViewCell.swift; sourceTree = "<group>"; };
 		77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
+		77CB027A29D02FA1006817E5 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
 		77D32D40292A0EDD006E6314 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		77D32D42292CD6A2006E6314 /* SideBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarView.swift; sourceTree = "<group>"; };
 		77E70F452930951100F55CD7 /* UITextField + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField + Extension.swift"; sourceTree = "<group>"; };
@@ -350,6 +352,14 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		77CB027929D02BCF006817E5 /* APIServices */ = {
+			isa = PBXGroup;
+			children = (
+				77CB027A29D02FA1006817E5 /* UserAPIService.swift */,
+			);
+			path = APIServices;
+			sourceTree = "<group>";
+		};
 		77D32D3F292A0EC7006E6314 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -389,6 +399,7 @@
 		BD4E13632973DAA300AEA757 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				77CB027929D02BCF006817E5 /* APIServices */,
 				BD90E9DF2976C3EF00C7CB6B /* NetworkEnv.swift */,
 				BD4E13642973DAC400AEA757 /* NetworkError.swift */,
 				BD90E9E12976C4F800C7CB6B /* Networking.swift */,
@@ -1137,6 +1148,7 @@
 				BDC20F9A293B446D00B9A2E7 /* SplashViewController.swift in Sources */,
 				7761D4F6292F3749003971DC /* FogNavigationView.swift in Sources */,
 				77650202295448AE002BF7AD /* SettingViewController.swift in Sources */,
+				77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */,
 				77650212295463B8002BF7AD /* BaseTableViewCell.swift in Sources */,
 				ECA425782922545C004DFDAF /* MapViewController.swift in Sources */,
 				BD347C63292FEA15009F52BA /* RoadPopUpView.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */; };
 		77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */; };
 		77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */; };
+		77CB027829D02863006817E5 /* NicknameResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027729D02863006817E5 /* NicknameResModel.swift */; };
 		77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027A29D02FA1006817E5 /* UserAPIService.swift */; };
 		77D32D41292A0EDD006E6314 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D40292A0EDD006E6314 /* ViewModelType.swift */; };
 		77D32D43292CD6A3006E6314 /* SideBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D42292CD6A2006E6314 /* SideBarView.swift */; };
@@ -135,6 +136,7 @@
 		776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTitleTableViewCell.swift; sourceTree = "<group>"; };
 		77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
+		77CB027729D02863006817E5 /* NicknameResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameResModel.swift; sourceTree = "<group>"; };
 		77CB027A29D02FA1006817E5 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
 		77D32D40292A0EDD006E6314 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		77D32D42292CD6A2006E6314 /* SideBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarView.swift; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				BD90E9DB2976C02100C7CB6B /* CommonResponse.swift */,
+				77CB027729D02863006817E5 /* NicknameResModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1146,6 +1149,7 @@
 				BD347C60292FD4C8009F52BA /* FogButton.swift in Sources */,
 				ECA4257E292254C6004DFDAF /* BaseViewController.swift in Sources */,
 				BDC20F9A293B446D00B9A2E7 /* SplashViewController.swift in Sources */,
+				77CB027829D02863006817E5 /* NicknameResModel.swift in Sources */,
 				7761D4F6292F3749003971DC /* FogNavigationView.swift in Sources */,
 				77650202295448AE002BF7AD /* SettingViewController.swift in Sources */,
 				77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */; };
 		77CB027829D02863006817E5 /* NicknameResModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027729D02863006817E5 /* NicknameResModel.swift */; };
 		77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027A29D02FA1006817E5 /* UserAPIService.swift */; };
+		77CB027F29DEAE57006817E5 /* RxMoya + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */; };
 		77D32D41292A0EDD006E6314 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D40292A0EDD006E6314 /* ViewModelType.swift */; };
 		77D32D43292CD6A3006E6314 /* SideBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D42292CD6A2006E6314 /* SideBarView.swift */; };
 		77E70F462930951100F55CD7 /* UITextField + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E70F452930951100F55CD7 /* UITextField + Extension.swift */; };
@@ -138,6 +139,7 @@
 		77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
 		77CB027729D02863006817E5 /* NicknameResModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameResModel.swift; sourceTree = "<group>"; };
 		77CB027A29D02FA1006817E5 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
+		77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxMoya + Extension.swift"; sourceTree = "<group>"; };
 		77D32D40292A0EDD006E6314 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		77D32D42292CD6A2006E6314 /* SideBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarView.swift; sourceTree = "<group>"; };
 		77E70F452930951100F55CD7 /* UITextField + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField + Extension.swift"; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 		ECA4256F292253AF004DFDAF /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */,
 				ECA4259829229BD9004DFDAF /* UIFont + Extension.swift */,
 				ECA425D62924DA66004DFDAF /* Bundle + Extension.swift */,
 				77F1D82129269CC800F31D0C /* UIColor + Extension.swift */,
@@ -1124,6 +1127,7 @@
 				77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */,
 				ECA4259729229B15004DFDAF /* FogFont.swift in Sources */,
 				BDC50ED2292A07EB002378C6 /* BottomDetailViewModel.swift in Sources */,
+				77CB027F29DEAE57006817E5 /* RxMoya + Extension.swift in Sources */,
 				BD90E9DC2976C02100C7CB6B /* CommonResponse.swift in Sources */,
 				BD347C5A292FD226009F52BA /* ExMapType.swift in Sources */,
 				77F1D82229269CC800F31D0C /* UIColor + Extension.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
@@ -17,10 +17,9 @@ class UserAPIService: Networking {
     static let shared = UserAPIService()
     var provider = NetworkProvider<API>()
     
-    func getUserNickname(userId: Int) -> Single<NicknameResModel> {
+    // 유저 닉네임 조회
+    func getUserNickname(userId: Int) -> Single<NicknameResModel?> {
         return provider.request(.getNickname(userId: userId))
-            .map { response in
-                try JSONDecoder().decode(NicknameResModel.self, from: response.data)
-            }
+            .map(NicknameResModel.self)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
@@ -1,0 +1,26 @@
+//
+//  UserAPIService.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/03/26.
+//
+
+import Foundation
+
+import Moya
+import RxCocoa
+import RxSwift
+
+class UserAPIService: Networking {
+    typealias API = UserAPI
+    
+    static let shared = UserAPIService()
+    var provider = NetworkProvider<API>()
+    
+    func getUserNickname(userId: Int) -> Single<NicknameResModel> {
+        return provider.request(.getNickname(userId: userId))
+            .map { response in
+                try JSONDecoder().decode(NicknameResModel.self, from: response.data)
+            }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
@@ -20,8 +20,8 @@ class UserAPIService: Networking {
     private init() {}
     
     // 유저 닉네임 조회
-    func getUserNickname(userId: Int) -> Single<NicknameResModel?> {
+    func getUserNickname(userId: Int) -> Single<NicknameResponseModel?> {
         return provider.request(.getNickname(userId: userId))
-            .map(NicknameResModel.self)
+            .map(NicknameResponseModel.self)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
@@ -17,6 +17,8 @@ class UserAPIService: Networking {
     static let shared = UserAPIService()
     var provider = NetworkProvider<API>()
     
+    private init() {}
+    
     // 유저 닉네임 조회
     func getUserNickname(userId: Int) -> Single<NicknameResModel?> {
         return provider.request(.getNickname(userId: userId))

--- a/FogFog-iOS/FogFog-iOS/Networking/APIs/UserAPI.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIs/UserAPI.swift
@@ -10,6 +10,7 @@ import Moya
 enum UserAPI {
     case preferredMap(userId: String)
     case withdrawal(userId: String)
+    case getNickname(userId: Int)
 }
 
 extension UserAPI: FogAPI {
@@ -24,6 +25,8 @@ extension UserAPI: FogAPI {
             return "/\(userId)/preffered-map"
         case .withdrawal(let userId):
             return "/\(userId)"
+        case .getNickname(let userId):
+            return "/\(userId)/nickname"
         }
     }
     
@@ -33,21 +36,21 @@ extension UserAPI: FogAPI {
             return .patch
         case .withdrawal:
             return .delete
+        case .getNickname:
+            return .get
         }
     }
     
     var parameters: [String: String]? {
         switch self {
-        case .preferredMap, .withdrawal:
+        case .preferredMap, .withdrawal, .getNickname:
             return nil
         }
     }
     
     var error: [Int : NetworkError]? {
         switch self {
-        case .preferredMap:
-            return nil
-        case .withdrawal:
+        case .preferredMap, .withdrawal, .getNickname:
             return nil
         /*
          case .nickname:

--- a/FogFog-iOS/FogFog-iOS/Networking/Models/NicknameResModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Models/NicknameResModel.swift
@@ -1,0 +1,12 @@
+//
+//  NicknameResModel.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/03/26.
+//
+
+import Foundation
+
+struct NicknameResModel: Codable {
+    let nickname: String
+}

--- a/FogFog-iOS/FogFog-iOS/Networking/Models/NicknameResponseModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Models/NicknameResponseModel.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct NicknameResModel: Codable {
+struct NicknameResponseModel: Codable {
     let nickname: String
 }

--- a/FogFog-iOS/FogFog-iOS/Networking/NetworkEnv.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/NetworkEnv.swift
@@ -17,7 +17,7 @@ extension NetworkEnv {
     enum HTTPHeaderFields {
         static let `default`: [String: String] = [
             "Content-Type": "application/json",
-            "accessToken": ""
+            "Authorization": ""
         ]
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -92,6 +92,7 @@ extension MapViewController {
     
     private func bind() {
         let input = MapViewModel.Input(
+            viewDidLoad: Signal<Void>.just(()),
             tapMenuButton: navigationView.menuButton.rx.tap.asSignal(),
             tapBlurEffectView: tapBlurEffectView.asSignal(),
             tapSettingButton: sideBarView.settingButtonDidTap())
@@ -106,6 +107,12 @@ extension MapViewController {
         
         output.didSettingButtonTapped
             .emit()
+            .disposed(by: disposeBag)
+        
+        output.userNickname
+            .subscribe(onNext: { result in
+                self.sideBarView.nicknameLabel.text = result
+            })
             .disposed(by: disposeBag)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -76,7 +76,7 @@ extension MapViewModel {
     func getUserNicknameAPI(userId: Int) {
         UserAPIService.shared.getUserNickname(userId: userId)
             .subscribe(onSuccess: { result in
-                self.userNickname.onNext(result.nickname)
+                self.userNickname.onNext(result?.nickname ?? "")
             }, onFailure: { error in
                 if let networkError = error as? NetworkError {
                     switch networkError {

--- a/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
@@ -17,7 +17,7 @@ final class SideBarView: BaseView {
     private let blueView = UIView()
     private let logoImageView = UIImageView()
     private let titleLabel = UILabel()
-    private let nicknameLabel = UILabel()
+    let nicknameLabel = UILabel()
     private let settingButton = UIButton()
     private let mapSettingContainerView = UIView()
     private let mapLogoImageView = UIImageView()

--- a/FogFog-iOS/FogFog-iOS/Supports/Info.plist
+++ b/FogFog-iOS/FogFog-iOS/Supports/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>

--- a/FogFog-iOS/FogFog-iOS/Utils/Extension/RxMoya + Extension.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Extension/RxMoya + Extension.swift
@@ -1,0 +1,42 @@
+//
+//  RxMoya + Extension.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/04/04.
+//
+
+import Foundation
+
+import Moya
+import RxSwift
+
+extension PrimitiveSequence where Trait == SingleTrait, Element == Moya.Response {
+
+    var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        return decoder
+    }
+
+    /// Wrap to common response
+    /// - Common response로 감싼 객체로 매핑해주는 메소드
+    func map<Response: Decodable>(
+        _ type: Response.Type
+    ) -> PrimitiveSequence<Trait, CommonResponse<Response>> {
+        return map(CommonResponse<Response>.self, using: decoder)
+    }
+
+    /// Map to pure
+    /// - Pure data로 매핑해주는 메소드(아래 설명 참조)
+    /// - 옵셔널 타입으로 반환합니다.
+    /*
+    - statusCode
+    - success
+    - message
+    - data? <- Pure data in our service
+    */
+    func map<Response: Decodable>(
+        _ type: Response.Type
+    ) -> PrimitiveSequence<Trait, Response?> {
+        return map(Response.self).map { $0.data }
+    }
+}


### PR DESCRIPTION
## 🔍 What is this PR?
닉네임 조회 API를 연결했습니다.

## 📝 Changes
- `NetworkEnv` 파일 - HTTPHeaderFields 부분 `accesstoken` -> `Authorization` 수정 
    - 헤더로 `accesstoken` 넘길 때  "Bearer accesstoken" 형식으로 보내줘야 해서 Bearer도 디폴트로 박아두면 좋을 것 같은데 요부분 확인 부탁드립니다!! (일단은 ""로 비워둔 상태)
- 지금 테스트용으로 `userId == 2` 로 고정해둔 상태이고 로그인 연결 후 유저 정보로 바꿔줄 예정입니다.
- 닉네임 조회 API 호출시점도 `MapViewController`의 `ViewDidLoad` 시점으로 테스트 해둔 상태인데 이 부분도 로그인 API 연결 후 로그인 성공 시점, 유저가 닉네임 수정했을 때 갱신해주는 방식으로 수정하려고 합니다! 참고 부탁드립니다 ~
- 디코딩 부분 도와준 @Taehyeon-Kim 에게 무한 감사..

**+** @seungchan2 열린 피알 빠른 머지 부탁드립니당

## 📸 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 사이드 바 화면 | <img src="https://user-images.githubusercontent.com/63277563/231475251-fa1a2414-57f7-40ca-ad14-3675869ca6ba.PNG" width="300"> |

## ☑️ Test Checklist

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #42 
