### PR TITLE
[#49] 카카오 인증 플로우 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/swift,xcode,macos,cocoapods
+
+## Config
+*.xcconfig

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		BD4D62A92A1A0FB200532778 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = BD4D62A82A1A0FB200532778 /* RxKakaoSDKAuth */; };
 		BD4D62AB2A1A0FB200532778 /* RxKakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = BD4D62AA2A1A0FB200532778 /* RxKakaoSDKCommon */; };
 		BD4D62AD2A1A0FB200532778 /* RxKakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = BD4D62AC2A1A0FB200532778 /* RxKakaoSDKUser */; };
+		BD4D62AF2A1A100B00532778 /* KakaoOAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4D62AE2A1A100B00532778 /* KakaoOAuthService.swift */; };
 		BD4E13652973DAC400AEA757 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4E13642973DAC400AEA757 /* NetworkError.swift */; };
 		BD5D0D7029F12E0600190471 /* MessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5D0D6F29F12E0600190471 /* MessageModel.swift */; };
 		BD5D0D7429F1302F00190471 /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5D0D7329F1302F00190471 /* Presentable.swift */; };
@@ -73,6 +74,10 @@
 		BDC50ED2292A07EB002378C6 /* SmokingAreaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */; };
 		BDC50ED6292A09BD002378C6 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED5292A09BD002378C6 /* BaseView.swift */; };
 		BDDAA3912A249D090055859E /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3902A249D090055859E /* Config.swift */; };
+		BDDAA3932A24B9D00055859E /* OAuthServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3922A24B9D00055859E /* OAuthServiceType.swift */; };
+		BDDAA3952A24BA130055859E /* OAuthAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */; };
+		BDDAA3972A24BC120055859E /* OAuthProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3962A24BC120055859E /* OAuthProviderType.swift */; };
+		BDE3EEB22A1D124300632662 /* OAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE3EEB12A1D124300632662 /* OAuthService.swift */; };
 		BDEA50D129261C6600110982 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = BDEA50D029261C6600110982 /* .swiftlint.yml */; };
 		ECA4252D29224DB8004DFDAF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4252C29224DB8004DFDAF /* AppDelegate.swift */; };
 		ECA4252F29224DB8004DFDAF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4252E29224DB8004DFDAF /* SceneDelegate.swift */; };
@@ -168,6 +173,7 @@
 		BD347C62292FEA15009F52BA /* RoadPopUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadPopUpView.swift; sourceTree = "<group>"; };
 		BD347C64292FEB08009F52BA /* RoadPopUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoadPopUpViewModel.swift; sourceTree = "<group>"; };
 		BD4B550E292A29EC00ECFD04 /* SmokingAreaResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokingAreaResponseModel.swift; sourceTree = "<group>"; };
+		BD4D62AE2A1A100B00532778 /* KakaoOAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoOAuthService.swift; sourceTree = "<group>"; };
 		BD4E13642973DAC400AEA757 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		BD5D0D6F29F12E0600190471 /* MessageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageModel.swift; sourceTree = "<group>"; };
 		BD5D0D7329F1302F00190471 /* Presentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
@@ -188,6 +194,10 @@
 		BDC50ED5292A09BD002378C6 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		BDDAA38F2A249B550055859E /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		BDDAA3902A249D090055859E /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		BDDAA3922A24B9D00055859E /* OAuthServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthServiceType.swift; sourceTree = "<group>"; };
+		BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthentication.swift; sourceTree = "<group>"; };
+		BDDAA3962A24BC120055859E /* OAuthProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthProviderType.swift; sourceTree = "<group>"; };
+		BDE3EEB12A1D124300632662 /* OAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthService.swift; sourceTree = "<group>"; };
 		BDEA50D029261C6600110982 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D67B489E657987D4A7AD92C7 /* Pods_FogFog_iOS_FogFog_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FogFog_iOS_FogFog_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DABD884BD50346C82E3C3CA3 /* Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOS-FogFog-iOSUITests/Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -529,6 +539,18 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		BDE3EEB02A1D10DC00632662 /* OAuth */ = {
+			isa = PBXGroup;
+			children = (
+				BD4D62AE2A1A100B00532778 /* KakaoOAuthService.swift */,
+				BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */,
+				BDDAA3962A24BC120055859E /* OAuthProviderType.swift */,
+				BDE3EEB12A1D124300632662 /* OAuthService.swift */,
+				BDDAA3922A24B9D00055859E /* OAuthServiceType.swift */,
+			);
+			path = OAuth;
+			sourceTree = "<group>";
+		};
 		ECA4252029224DB8004DFDAF = {
 			isa = PBXGroup;
 			children = (
@@ -556,10 +578,11 @@
 			isa = PBXGroup;
 			children = (
 				BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */,
-				BD9AA41629929AB200D4E7CE /* Manager */,
 				ECA4255D292251D8004DFDAF /* App */,
+				BD9AA41629929AB200D4E7CE /* Manager */,
 				ECA4255E292251E0004DFDAF /* Models */,
 				BD4E13632973DAA300AEA757 /* Networking */,
+				BDE3EEB02A1D10DC00632662 /* OAuth */,
 				ECA4255F2922528B004DFDAF /* Presentation */,
 				ECA4256029225297004DFDAF /* Resources */,
 				ECA425612922529F004DFDAF /* Supports */,
@@ -1162,8 +1185,10 @@
 				BD5D0D7C29F14FDC00190471 /* SmokingAreaMessageView.swift in Sources */,
 				77650216295487A7002BF7AD /* SettingNicknameTableViewCell.swift in Sources */,
 				77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */,
+				BD4D62AF2A1A100B00532778 /* KakaoOAuthService.swift in Sources */,
 				77E70F4A2930D0FA00F55CD7 /* MakeNicknameViewModel.swift in Sources */,
 				77650210295462D7002BF7AD /* UIViewController + Extension.swift in Sources */,
+				BDDAA3952A24BA130055859E /* OAuthAuthentication.swift in Sources */,
 				7765020E29546239002BF7AD /* SettingListTableViewCell.swift in Sources */,
 				ECA425DA29253155004DFDAF /* Coordinator.swift in Sources */,
 				ECA425F4292634A6004DFDAF /* LoginViewController.swift in Sources */,
@@ -1181,10 +1206,13 @@
 				BD4B550F292A29EC00ECFD04 /* SmokingAreaResponseModel.swift in Sources */,
 				ECA425F6292634C9004DFDAF /* LoginViewModel.swift in Sources */,
 				BD90E9E22976C4F800C7CB6B /* Networking.swift in Sources */,
+				BDE3EEB22A1D124300632662 /* OAuthService.swift in Sources */,
 				77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */,
+				BDDAA3932A24B9D00055859E /* OAuthServiceType.swift in Sources */,
 				ECA4259729229B15004DFDAF /* FogFont.swift in Sources */,
 				BDC50ED2292A07EB002378C6 /* SmokingAreaDetailViewModel.swift in Sources */,
 				77CB027F29DEAE57006817E5 /* RxMoya + Extension.swift in Sources */,
+				BDDAA3972A24BC120055859E /* OAuthProviderType.swift in Sources */,
 				BD90E9DC2976C02100C7CB6B /* CommonResponse.swift in Sources */,
 				BD347C5A292FD226009F52BA /* ExMapType.swift in Sources */,
 				77F1D82229269CC800F31D0C /* UIColor + Extension.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		BDC50ECB292A07B2002378C6 /* GoogleMap.plist in Resources */ = {isa = PBXBuildFile; fileRef = BDC50ECA292A07B2002378C6 /* GoogleMap.plist */; };
 		BDC50ED2292A07EB002378C6 /* SmokingAreaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */; };
 		BDC50ED6292A09BD002378C6 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED5292A09BD002378C6 /* BaseView.swift */; };
+		BDDAA3912A249D090055859E /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3902A249D090055859E /* Config.swift */; };
 		BDEA50D129261C6600110982 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = BDEA50D029261C6600110982 /* .swiftlint.yml */; };
 		ECA4252D29224DB8004DFDAF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4252C29224DB8004DFDAF /* AppDelegate.swift */; };
 		ECA4252F29224DB8004DFDAF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4252E29224DB8004DFDAF /* SceneDelegate.swift */; };
@@ -185,6 +186,8 @@
 		BDC50ECA292A07B2002378C6 /* GoogleMap.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
 		BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokingAreaDetailViewModel.swift; sourceTree = "<group>"; };
 		BDC50ED5292A09BD002378C6 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		BDDAA38F2A249B550055859E /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		BDDAA3902A249D090055859E /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		BDEA50D029261C6600110982 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D67B489E657987D4A7AD92C7 /* Pods_FogFog_iOS_FogFog_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FogFog_iOS_FogFog_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DABD884BD50346C82E3C3CA3 /* Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOS-FogFog-iOSUITests/Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -631,6 +634,7 @@
 			children = (
 				ECA4253A29224DBB004DFDAF /* Info.plist */,
 				BDC50ECA292A07B2002378C6 /* GoogleMap.plist */,
+				BDDAA38F2A249B550055859E /* Config.xcconfig */,
 			);
 			path = Supports;
 			sourceTree = "<group>";
@@ -797,6 +801,7 @@
 			isa = PBXGroup;
 			children = (
 				ECA425DD29253292004DFDAF /* CoordinatorCase.swift */,
+				BDDAA3902A249D090055859E /* Config.swift */,
 			);
 			path = Contstant;
 			sourceTree = "<group>";
@@ -1217,6 +1222,7 @@
 				BD5D0D7429F1302F00190471 /* Presentable.swift in Sources */,
 				BDC20F9D293B44B600B9A2E7 /* FogToast.swift in Sources */,
 				BD5D0D7629F1310800190471 /* SmokingAreaCardView.swift in Sources */,
+				BDDAA3912A249D090055859E /* Config.swift in Sources */,
 				ECA425E429262A37004DFDAF /* DefaultMapCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1267,6 +1273,7 @@
 /* Begin XCBuildConfiguration section */
 		ECA4255129224DBB004DFDAF /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BDDAA38F2A249B550055859E /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1327,6 +1334,7 @@
 		};
 		ECA4255229224DBB004DFDAF /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BDDAA38F2A249B550055859E /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -52,6 +52,9 @@
 		BD347C63292FEA15009F52BA /* RoadPopUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD347C62292FEA15009F52BA /* RoadPopUpView.swift */; };
 		BD347C65292FEB08009F52BA /* RoadPopUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD347C64292FEB08009F52BA /* RoadPopUpViewModel.swift */; };
 		BD4B550F292A29EC00ECFD04 /* SmokingAreaResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4B550E292A29EC00ECFD04 /* SmokingAreaResponseModel.swift */; };
+		BD4D62A92A1A0FB200532778 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = BD4D62A82A1A0FB200532778 /* RxKakaoSDKAuth */; };
+		BD4D62AB2A1A0FB200532778 /* RxKakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = BD4D62AA2A1A0FB200532778 /* RxKakaoSDKCommon */; };
+		BD4D62AD2A1A0FB200532778 /* RxKakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = BD4D62AC2A1A0FB200532778 /* RxKakaoSDKUser */; };
 		BD4E13652973DAC400AEA757 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4E13642973DAC400AEA757 /* NetworkError.swift */; };
 		BD5D0D7029F12E0600190471 /* MessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5D0D6F29F12E0600190471 /* MessageModel.swift */; };
 		BD5D0D7429F1302F00190471 /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD5D0D7329F1302F00190471 /* Presentable.swift */; };
@@ -237,7 +240,9 @@
 			files = (
 				ECA425CD29234C4F004DFDAF /* RxSwift in Frameworks */,
 				ECA425B229234744004DFDAF /* Moya in Frameworks */,
+				BD4D62AB2A1A0FB200532778 /* RxKakaoSDKCommon in Frameworks */,
 				ECA425A4292346BF004DFDAF /* Kingfisher in Frameworks */,
+				BD4D62A92A1A0FB200532778 /* RxKakaoSDKAuth in Frameworks */,
 				ECA4259E292346A2004DFDAF /* Then in Frameworks */,
 				ECA425C929234C4F004DFDAF /* RxCocoa in Frameworks */,
 				ECA425B429234744004DFDAF /* RxMoya in Frameworks */,
@@ -245,6 +250,7 @@
 				ECA425CB29234C4F004DFDAF /* RxRelay in Frameworks */,
 				772577DC2934924E008273A7 /* RxGesture in Frameworks */,
 				1DDE6DAB87E9F15EAEAD8A1B /* Pods_FogFog_iOS.framework in Frameworks */,
+				BD4D62AD2A1A0FB200532778 /* RxKakaoSDKUser in Frameworks */,
 				772577D929349212008273A7 /* RxKeyboard in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -878,6 +884,9 @@
 				ECA425CC29234C4F004DFDAF /* RxSwift */,
 				772577D829349212008273A7 /* RxKeyboard */,
 				772577DB2934924E008273A7 /* RxGesture */,
+				BD4D62A82A1A0FB200532778 /* RxKakaoSDKAuth */,
+				BD4D62AA2A1A0FB200532778 /* RxKakaoSDKCommon */,
+				BD4D62AC2A1A0FB200532778 /* RxKakaoSDKUser */,
 			);
 			productName = "FogFog-iOS";
 			productReference = ECA4252929224DB8004DFDAF /* FogFog-iOS.app */;
@@ -962,6 +971,7 @@
 				ECA425C729234C4F004DFDAF /* XCRemoteSwiftPackageReference "RxSwift" */,
 				772577D729349212008273A7 /* XCRemoteSwiftPackageReference "RxKeyboard" */,
 				772577DA2934924D008273A7 /* XCRemoteSwiftPackageReference "RxGesture" */,
+				BD4D62A72A1A0FB200532778 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */,
 			);
 			productRefGroup = ECA4252A29224DB8004DFDAF /* Products */;
 			projectDirPath = "";
@@ -1575,6 +1585,14 @@
 				minimumVersion = 4.0.0;
 			};
 		};
+		BD4D62A72A1A0FB200532778 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk-rx";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		ECA4259C292346A2004DFDAF /* XCRemoteSwiftPackageReference "Then" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/devxoul/Then.git";
@@ -1627,6 +1645,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 772577DA2934924D008273A7 /* XCRemoteSwiftPackageReference "RxGesture" */;
 			productName = RxGesture;
+		};
+		BD4D62A82A1A0FB200532778 /* RxKakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BD4D62A72A1A0FB200532778 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKAuth;
+		};
+		BD4D62AA2A1A0FB200532778 /* RxKakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BD4D62A72A1A0FB200532778 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKCommon;
+		};
+		BD4D62AC2A1A0FB200532778 /* RxKakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BD4D62A72A1A0FB200532778 /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKUser;
 		};
 		ECA4259D292346A2004DFDAF /* Then */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -1397,8 +1397,8 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 권한 체크";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1407,9 +1407,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fogfog.FogFog-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FogFog_Debug;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -1431,8 +1435,8 @@
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치 권한 체크";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1441,9 +1445,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fogfog.FogFog-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FogFog_Release;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		BD90E9E02976C3EF00C7CB6B /* NetworkEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD90E9DF2976C3EF00C7CB6B /* NetworkEnv.swift */; };
 		BD90E9E22976C4F800C7CB6B /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD90E9E12976C4F800C7CB6B /* Networking.swift */; };
 		BD9AA41829929ABD00D4E7CE /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */; };
+		BDC0D0832A2600D9003D770E /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC0D0822A2600D9003D770E /* AuthAPI.swift */; };
+		BDC0D0852A26035D003D770E /* AuthAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC0D0842A26035D003D770E /* AuthAPIService.swift */; };
 		BDC20F9A293B446D00B9A2E7 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */; };
 		BDC20F9D293B44B600B9A2E7 /* FogToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F9C293B44B600B9A2E7 /* FogToast.swift */; };
 		BDC50ECB292A07B2002378C6 /* GoogleMap.plist in Resources */ = {isa = PBXBuildFile; fileRef = BDC50ECA292A07B2002378C6 /* GoogleMap.plist */; };
@@ -187,6 +189,8 @@
 		BD90E9E12976C4F800C7CB6B /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "FogFog-iOS.entitlements"; sourceTree = "<group>"; };
 		BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
+		BDC0D0822A2600D9003D770E /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		BDC0D0842A26035D003D770E /* AuthAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIService.swift; sourceTree = "<group>"; };
 		BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		BDC20F9C293B44B600B9A2E7 /* FogToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogToast.swift; sourceTree = "<group>"; };
 		BDC50ECA292A07B2002378C6 /* GoogleMap.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
@@ -386,6 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				77CB027A29D02FA1006817E5 /* UserAPIService.swift */,
+				BDC0D0842A26035D003D770E /* AuthAPIService.swift */,
 			);
 			path = APIServices;
 			sourceTree = "<group>";
@@ -485,6 +490,7 @@
 			children = (
 				BD90E9DD2976C11E00C7CB6B /* FogAPI.swift */,
 				BD2D276A297D17E400984B97 /* UserAPI.swift */,
+				BDC0D0822A2600D9003D770E /* AuthAPI.swift */,
 			);
 			path = APIs;
 			sourceTree = "<group>";
@@ -1182,6 +1188,7 @@
 				BD347C58292FD1BC009F52BA /* RoadPopUpViewController.swift in Sources */,
 				7765020429544937002BF7AD /* SettingViewModel.swift in Sources */,
 				77F1D82F2927F2CC00F31D0C /* Adjusted + Extension.swift in Sources */,
+				BDC0D0852A26035D003D770E /* AuthAPIService.swift in Sources */,
 				BD5D0D7C29F14FDC00190471 /* SmokingAreaMessageView.swift in Sources */,
 				77650216295487A7002BF7AD /* SettingNicknameTableViewCell.swift in Sources */,
 				77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */,
@@ -1194,6 +1201,7 @@
 				ECA425F4292634A6004DFDAF /* LoginViewController.swift in Sources */,
 				ECA425CF292382AD004DFDAF /* NavigationView.swift in Sources */,
 				77F899DE29308C6000806896 /* FogTextField.swift in Sources */,
+				BDC0D0832A2600D9003D770E /* AuthAPI.swift in Sources */,
 				BD347C65292FEB08009F52BA /* RoadPopUpViewModel.swift in Sources */,
 				ECA425E0292532B7004DFDAF /* AppCoordinator.swift in Sources */,
 				ECA425E629262A42004DFDAF /* DefaultLoginCoordinator.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,24 @@
       }
     },
     {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk.git",
+      "state" : {
+        "revision" : "d788f9a5a888f16253b9c3d9f3bd794835708c3f",
+        "version" : "2.15.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk-rx",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
+      "state" : {
+        "revision" : "ba12deed6bf97f6ac275cc1257fe7dd411e96afc",
+        "version" : "2.15.0"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
@@ -28,12 +46,48 @@
       }
     },
     {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
       "identity" : "reactiveswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
       "state" : {
         "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
         "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxalamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxAlamofire.git",
+      "state" : {
+        "revision" : "9535b58695b91fb67f56d58d6fd0c76462d7743a",
+        "version" : "6.1.2"
+      }
+    },
+    {
+      "identity" : "rxgesture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxGesture.git",
+      "state" : {
+        "revision" : "1b137c576b4aaaab949235752278956697c9e4a0",
+        "version" : "4.0.4"
+      }
+    },
+    {
+      "identity" : "rxkeyboard",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxKeyboard.git",
+      "state" : {
+        "revision" : "63f6377975c962a1d89f012a6f1e5bebb2c502b7",
+        "version" : "2.0.1"
       }
     },
     {

--- a/FogFog-iOS/FogFog-iOS/App/AppDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/App/AppDelegate.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 import GoogleMaps
+import RxKakaoSDKAuth
+import KakaoSDKAuth
+import RxKakaoSDKCommon
 import KakaoSDKCommon
 
 @main
@@ -22,6 +25,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // MARK: - 카카오 SDK 초기화
         RxKakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
         return true
+    }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+            return AuthController.rx.handleOpenUrl(url: url)
+        }
+
+        return false
     }
 }
 

--- a/FogFog-iOS/FogFog-iOS/App/AppDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/App/AppDelegate.swift
@@ -8,14 +8,19 @@
 import UIKit
 
 import GoogleMaps
+import KakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-
+        
+        // MARK: - 구글 맵 설정
         GMSServices.provideAPIKey(Bundle.main.apiKey)
+        
+        // MARK: - 카카오 SDK 초기화
+        KakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
         return true
     }
 }

--- a/FogFog-iOS/FogFog-iOS/App/AppDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/App/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GMSServices.provideAPIKey(Bundle.main.apiKey)
         
         // MARK: - 카카오 SDK 초기화
-        KakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
+        RxKakaoSDK.initSDK(appKey: Config.kakaoNativeAppKey)
         return true
     }
 }

--- a/FogFog-iOS/FogFog-iOS/App/SceneDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/App/SceneDelegate.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import RxKakaoSDKAuth
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
@@ -21,5 +24,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.rx.handleOpenUrl(url: url)
+            }
+        }
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/AuthAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/AuthAPIService.swift
@@ -1,0 +1,65 @@
+//
+//  AuthAPIService.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/30.
+//
+
+import Foundation
+
+import Moya
+import RxCocoa
+import RxSwift
+
+protocol AuthAPIServiceType {
+    func login() -> Single<Void>
+}
+
+final class AuthAPIService: Networking, AuthAPIServiceType {
+    
+    // MARK: - Type Alias
+    
+    typealias API = AuthAPI
+    
+    // MARK: - Rx
+    
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Property
+    
+    private let provider = NetworkProvider<API>()
+    private var oauthService: OAuthServiceType
+    
+    // MARK: - Initialization
+    
+    init(oauthService: OAuthServiceType) {
+        self.oauthService = oauthService
+    }
+    
+    /// 로그인 메서드
+    /// OAuth 인증 --> 포그포그 서버 로그인/회원가입 인증 수행
+    /// OAuthService의 OAuthServiceType만 바꿔 끼워주더라도 인증 로직은 변경없이 수행됩니다.
+    func login() -> Single<Void> {
+        return oauthService
+            .authorize()
+            .do { oauthAuthentication in
+                // 성공 시 토큰 저장 --> keychain
+                print("✨ OAuth 인증 성공) \(oauthAuthentication)")
+            }
+            .map { $0.toSignInRequestDTO() }
+            .flatMap(signIn)
+            .do { dto in
+                print("🎉 로그인/회원가입 성공) \(dto?.id ?? -1) 유저님 환영합니다.")
+                print("🎉 액세스 토큰 \(dto?.accessToken ?? "")")
+                print("🎉 리프레시 토큰 \(dto?.refreshToken ?? "")")
+            }
+            .map { _ in () }
+    }
+    
+    // 실제 로그인/회원가입 Request
+    private func signIn(_ request: SignInRequestDTO) -> Single<SignInResponseDTO?> {
+        return provider
+            .request(.signIn(request: request))
+            .map(SignInResponseDTO.self)
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Networking/APIs/AuthAPI.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIs/AuthAPI.swift
@@ -1,0 +1,65 @@
+//
+//  AuthAPI.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/30.
+//
+
+import Moya
+
+struct SignInRequestDTO: Codable {
+    let socialType: String
+    let kakaoAccessToken: String?
+    let idToken: String?
+    let code: String?
+}
+
+struct SignInResponseDTO: Codable {
+    let accessToken: String
+    let refreshToken: String
+    let id: Int
+}
+
+enum AuthAPI {
+    case signIn(request: SignInRequestDTO)
+}
+
+extension AuthAPI: FogAPI {
+    
+    var domain: FogDomain {
+        return .auth
+    }
+    
+    var urlPath: String {
+        switch self {
+        case .signIn:
+            return "/signin"
+        }
+    }
+    
+    var method: Method {
+        switch self {
+        case .signIn:
+            return .post
+        }
+    }
+    
+    var parameters: [String: String]? {
+        switch self {
+        case let .signIn(request):
+            return [
+                "socialType": request.socialType,
+                "kakaoAccessToken": request.kakaoAccessToken ?? "",
+                "idToken": request.idToken ?? "",
+                "code": request.code ?? ""
+            ]
+        }
+    }
+    
+    var error: [Int: NetworkError]? {
+        switch self {
+        case .signIn:
+            return nil
+        }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Networking/APIs/FogAPI.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIs/FogAPI.swift
@@ -11,7 +11,7 @@ import Moya
 
 /// FogFog 도메인
 enum FogDomain {
-    case auth(path: String)
+    case auth
     case maps
     case users
 }
@@ -56,13 +56,13 @@ extension FogAPI {
         return .successCodes
     }
     
-    var headers: [String : String]? {
+    var headers: [String: String]? {
         switch self {
         default:
             return NetworkEnv.HTTPHeaderFields.default
         }
     }
-
+    
     var task: Task {
         if let parameters = parameters {
             return .requestParameters(parameters: parameters, encoding: JSONEncoding.default)

--- a/FogFog-iOS/FogFog-iOS/OAuth/KakaoOAuthService.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/KakaoOAuthService.swift
@@ -16,7 +16,7 @@ final class KakaoOAuthService: OAuthServiceType {
     private let disposeBag = DisposeBag()
     
     func authorize() -> Single<OAuthAuthentication> {
-        return self.login().map { .init(oauthType: .kakao, token: $0.accessToken) }
+        return login().map { OAuthAuthentication(oauthType: .kakao, kakaoAccessToken: $0.accessToken) }
     }
 
     private func login() -> Single<OAuthToken> {

--- a/FogFog-iOS/FogFog-iOS/OAuth/KakaoOAuthService.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/KakaoOAuthService.swift
@@ -1,0 +1,47 @@
+//
+//  KakaoOAuthService.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/21.
+//
+
+import KakaoSDKAuth
+import KakaoSDKUser
+import RxKakaoSDKAuth
+import RxKakaoSDKUser
+import RxSwift
+
+final class KakaoOAuthService: OAuthServiceType {
+
+    private let disposeBag = DisposeBag()
+    
+    func authorize() -> Single<OAuthAuthentication> {
+        return self.login().map { .init(oauthType: .kakao, token: $0.accessToken) }
+    }
+
+    private func login() -> Single<OAuthToken> {
+        let isKakaoTalkLoginAvailable = UserApi.isKakaoTalkLoginAvailable()
+        
+        return Single.create { observer in
+            if isKakaoTalkLoginAvailable {
+                UserApi.shared.rx.loginWithKakaoTalk()
+                    .subscribe(onNext: { oAuthToken in
+                        observer(.success(oAuthToken))
+                    }, onError: { error in
+                        observer(.failure(error))
+                    })
+                    .disposed(by: self.disposeBag)
+            } else {
+                UserApi.shared.rx.loginWithKakaoAccount()
+                    .subscribe(onNext: { oAuthToken in
+                        observer(.success(oAuthToken))
+                    }, onError: { error in
+                        observer(.failure(error))
+                    })
+                    .disposed(by: self.disposeBag)
+            }
+            
+            return Disposables.create()
+        }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthAuthentication.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthAuthentication.swift
@@ -9,5 +9,19 @@ import Foundation
 
 struct OAuthAuthentication {
     var oauthType: OAuthProviderType
-    var token: String
+    var kakaoAccessToken: String?
+    var idToken: String?
+    var code: String?
+}
+
+extension OAuthAuthentication {
+    
+    func toSignInRequestDTO() -> SignInRequestDTO {
+        return .init(
+            socialType: oauthType.rawValue,
+            kakaoAccessToken: kakaoAccessToken,
+            idToken: idToken,
+            code: code
+        )
+    }
 }

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthAuthentication.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthAuthentication.swift
@@ -1,0 +1,13 @@
+//
+//  OAuthAuthentication.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/29.
+//
+
+import Foundation
+
+struct OAuthAuthentication {
+    var oauthType: OAuthProviderType
+    var token: String
+}

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthProviderType.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthProviderType.swift
@@ -1,0 +1,27 @@
+//
+//  OAuthProviderType.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/29.
+//
+
+import Foundation
+
+/**
+ - description: OAuth 서비스를 제공하는 제공자 종류
+    우리 서비스의 경우 Apple, Kakao 서비스 사용
+ */
+
+enum OAuthProviderType: String, Hashable, CaseIterable {
+    case kakao
+    case apple
+    
+    var servive: OAuthServiceType {
+        switch self {
+        case .kakao:
+            return KakaoOAuthService()
+        default:
+            return KakaoOAuthService()
+        }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthService.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthService.swift
@@ -1,0 +1,21 @@
+//
+//  OAuthService.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/24.
+//
+
+import RxSwift
+
+final class OAuthService {
+    
+    private let oAuthService: OAuthServiceType
+    
+    init(oAuthService: OAuthServiceType) {
+        self.oAuthService = oAuthService
+    }
+    
+    func authorize() -> Single<OAuthAuthentication> {
+        return oAuthService.authorize()
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthServiceType.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthServiceType.swift
@@ -1,0 +1,16 @@
+//
+//  OAuthServiceType.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/29.
+//
+
+/**
+ - description: OAuthService가 채택할 프로토콜
+ */
+
+import RxSwift
+
+protocol OAuthServiceType {
+    func authorize() -> Single<OAuthAuthentication>
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
@@ -24,10 +24,11 @@ final class DefaultLoginCoordinator: LoginCoordinator {
     
     func showLoginViewController() {
         let coordinator = DefaultLoginCoordinator(navigationController)
-        let kakao = KakaoOAuthService()
-        let oAuthService = OAuthService(oAuthService: kakao)
-        let dependency = LoginViewModel.Dependency(coordinator: coordinator, oAuthService: oAuthService)
-        let viewModel = LoginViewModel(dependency: dependency)
+        let viewModel = LoginViewModel(coordinator: coordinator) { oauthProviderType in
+            let oauthService = oauthProviderType.servive
+            let authService = AuthAPIService(oauthService: oauthService)
+            return authService
+        }
         let loginViewController = LoginViewController(viewModel: viewModel)
         navigationController.pushViewController(loginViewController, animated: false)
     }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
@@ -19,24 +19,26 @@ final class DefaultLoginCoordinator: LoginCoordinator {
     }
     
     func start() {
-        
         showLoginViewController()
     }
     
     func showLoginViewController() {
-        
+        let coordinator = DefaultLoginCoordinator(navigationController)
+        let kakao = KakaoOAuthService()
+        let oAuthService = OAuthService(oAuthService: kakao)
+        let dependency = LoginViewModel.Dependency(coordinator: coordinator, oAuthService: oAuthService)
+        let viewModel = LoginViewModel(dependency: dependency)
+        let loginViewController = LoginViewController(viewModel: viewModel)
+        navigationController.pushViewController(loginViewController, animated: false)
     }
     
     func connectMapCoordinator() {
-        
         let mapCoordinator = DefaultMapCoordinator(self.navigationController)
         mapCoordinator.start()
         self.childCoordinators.append(mapCoordinator)
     }
     
     func finish() {
-        
-        finishDelegate?
-            .didFinish(childCoordinator: self)
+        finishDelegate?.didFinish(childCoordinator: self)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxSwift
+
 final class LoginViewController: BaseViewController {
     
     // MARK: Properties
@@ -21,7 +23,8 @@ final class LoginViewController: BaseViewController {
     private let kakaoButton = UIButton()
     private let appleButton = UIButton()
     
-    private weak var viewModel: LoginViewModel?
+    private let viewModel: LoginViewModel
+    private let disposeBag = DisposeBag()
     
     // MARK: Init
     init(viewModel: LoginViewModel) {
@@ -36,6 +39,15 @@ final class LoginViewController: BaseViewController {
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        let input = LoginViewModel.Input(kakaoButtonDidTap: kakaoButton.rx.tap.asObservable())
+        let output = viewModel.transform(input: input)
+        
+        output.loginResult
+            .drive { msg in
+                print("로그인 메시지 \(msg)")
+            }
+            .disposed(by: disposeBag)
     }
     
     // MARK: UI

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -7,11 +7,55 @@
 
 import UIKit
 
-final class LoginViewModel {
+import RxCocoa
+import RxSwift
+
+final class LoginViewModel: ViewModelType {
     
-    private weak var coordinator: LoginCoordinator?
+    struct Dependency {
+        let coordinator: LoginCoordinator
+        // TODO: - AuthService로 교체해야 함
+        let oAuthService: OAuthService
+    }
     
-    init(coordinator: LoginCoordinator?) {
-        self.coordinator = coordinator
+    struct Input {
+        let kakaoButtonDidTap: Observable<Void>
+    }
+    
+    struct Output {
+        let loginResult: Driver<String>
+    }
+    
+    // MARK: - Property
+    
+    var disposeBag = DisposeBag()
+    private let coordinator: LoginCoordinator
+    private let oAuthService: OAuthService
+    
+    // MARK: - Initialization
+    
+    init(dependency: Dependency) {
+        self.coordinator = dependency.coordinator
+        self.oAuthService = dependency.oAuthService
+    }
+    
+    func transform(input: Input) -> Output {
+        let result = PublishSubject<String>()
+        
+        input.kakaoButtonDidTap
+            .flatMap(loginWithKakao)
+            // .(생략)자체 서버 회원가입/로그인
+            .subscribe { auth in
+                result.onNext("success: \(auth.token)")
+            } onError: { error in
+                result.onNext("error: \(error.localizedDescription)")
+            }
+            .disposed(by: disposeBag)
+        
+        return Output(loginResult: result.asDriver(onErrorDriveWith: .empty()))
+    }
+    
+    private func loginWithKakao() -> Observable<OAuthAuthentication> {
+        return oAuthService.authorize().asObservable()
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -11,13 +11,7 @@ import RxCocoa
 import RxSwift
 
 final class LoginViewModel: ViewModelType {
-    
-    struct Dependency {
-        let coordinator: LoginCoordinator
-        // TODO: - AuthService로 교체해야 함
-        let oAuthService: OAuthService
-    }
-    
+
     struct Input {
         let kakaoButtonDidTap: Observable<Void>
     }
@@ -29,14 +23,18 @@ final class LoginViewModel: ViewModelType {
     // MARK: - Property
     
     var disposeBag = DisposeBag()
+    
     private let coordinator: LoginCoordinator
-    private let oAuthService: OAuthService
+    private let factory: (OAuthProviderType) -> AuthAPIServiceType
     
     // MARK: - Initialization
     
-    init(dependency: Dependency) {
-        self.coordinator = dependency.coordinator
-        self.oAuthService = dependency.oAuthService
+    init(
+        coordinator: LoginCoordinator,
+        factory: @escaping (OAuthProviderType) -> AuthAPIServiceType
+    ) {
+        self.coordinator = coordinator
+        self.factory = factory
     }
     
     func transform(input: Input) -> Output {
@@ -44,9 +42,8 @@ final class LoginViewModel: ViewModelType {
         
         input.kakaoButtonDidTap
             .flatMap(loginWithKakao)
-            // .(생략)자체 서버 회원가입/로그인
-            .subscribe { auth in
-                result.onNext("success: \(auth.token)")
+            .subscribe { _ in
+                result.onNext("success!")
             } onError: { error in
                 result.onNext("error: \(error.localizedDescription)")
             }
@@ -55,7 +52,11 @@ final class LoginViewModel: ViewModelType {
         return Output(loginResult: result.asDriver(onErrorDriveWith: .empty()))
     }
     
-    private func loginWithKakao() -> Observable<OAuthAuthentication> {
-        return oAuthService.authorize().asObservable()
+    private func loginWithKakao() -> Observable<Void> {
+        return factory(.kakao).login().asObservable()
+    }
+    
+    private func loginWithApple() -> Observable<Void> {
+        return factory(.apple).login().asObservable()
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Supports/Info.plist
+++ b/FogFog-iOS/FogFog-iOS/Supports/Info.plist
@@ -4,6 +4,17 @@
 <dict>
 	<key>KAKAO_NATIVE_APP_KEY</key>
 	<string>${KAKAO_NATIVE_APP_KEY}</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao${KAKAO_NATIVE_APP_KEY}</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/FogFog-iOS/FogFog-iOS/Supports/Info.plist
+++ b/FogFog-iOS/FogFog-iOS/Supports/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>${KAKAO_NATIVE_APP_KEY}</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/FogFog-iOS/FogFog-iOS/Supports/Info.plist
+++ b/FogFog-iOS/FogFog-iOS/Supports/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/FogFog-iOS/FogFog-iOS/Utils/Contstant/Config.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Contstant/Config.swift
@@ -1,0 +1,19 @@
+//
+//  Config.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/05/29.
+//
+
+import Foundation
+
+enum Config {
+    
+    static var kakaoNativeAppKey: String {
+        guard let key = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] as? String else {
+            assertionFailure("KAKAO_NATIVE_APP_KEY could not found.")
+            return ""
+        }
+        return key
+    }
+}


### PR DESCRIPTION
## 🔍 What is this PR?
카카오 인증 플로우를 구현했습니다.

전체 인증 과정에서 일부만 구현했기 때문에 아직 완전하지 않아요.
아래에 어떤 것들을 구현했는지 적어놓았으니 읽어보시고 같이 추가적인 논의를 해보면 좋을 것 같습니다!

## 📝 Changes
### App Key와 같은 요소를 숨기기 위해서 Configuration 파일을 추가했어요

Admin Key가 아니라서 Native App Key를 Literal하게 사용해도 당장은 크게 문제는 없어보이지만 결국 Key라는 것이 보안적인 측면에서 중요하다고 판단하여 숨길 필요가 있다고 생각했어요. Private하게 관리할 수 있는 방법을 찾던 중에 Configuration 파일에 Key를 올려놓고, 이를 gitignore에 추가하면 안전하게 관리할 수 있다고 생각했습니다.

해당 파일은 팀 내에서 공유하는 것으로 하면 좋을 것 같습니다 :) (Slack에 올려놓을게요!!)

#### 현재 Supports 디렉토리 밑에 추가가 되어있어요!
![스크린샷 2023-05-29 오후 8 50 10](https://github.com/TeamFogFog/FogFog-iOS/assets/61109660/9839bbeb-dcf5-4645-ad7f-4c3cc86f5610)

#### 추가한 Configuration 파일은 설정해놓았습니다.
![스크린샷 2023-05-29 오후 8 51 14](https://github.com/TeamFogFog/FogFog-iOS/assets/61109660/ecbd812d-d657-4be0-b013-cd2c203cea2b)


### 우선 OAuth 인증 과정만 구현했어요
은주와 같이 인증 플로우를 구현하고 있는 상황이고, 일단 은주가 구현한 내용이 더 많은 것 같아서 일단 카카오 인증 플로우에서 Token을 받아오는 작업까지 구현했어요. 머지 이후에 논의하면서 맞춰가면 될 것 같아요!

<img width="1000" alt="스크린샷 2023-05-29 오후 8 42 08" src="https://github.com/TeamFogFog/FogFog-iOS/assets/61109660/6df21883-8c28-4d42-aea7-34b636f08ee7">

- 대략 위와 같은 형태로 구현을 했습니다.
- 현재 구현한 부분은 점선으로 둘러싼 부분이라고 봐주시면 될 것 같아요.

### 카카오 로그인 성공
카카오 로그인을 성공하면 OAuthAuthentication이라는 데이터 모델에 데이터가 담기게 됩니다.

### 카카오 로그인 실패(ft. Error Handling)
에러 타입은 아직 따로 구성은 안했는데 이것도 한 번 논의해보면 좋겠어요.

예를 들면 카카오 로그인/애플 로그인 도중에 사용자가 플로우를 취소하면 로그인 화면으로 돌아오잖아요?
이 때 취소한 경우라면 Alert에서 '로그인을 취소했어요.' 라는 메시지를 띄워주는 것도 UX적으로 좋아보입니다.

이 외에도 여러 상황에서 발생하는 에러타입이 있을 것 같아서 
LoginError와 같은 타입으로 에러를 정의하고 이에 맞는 메시지를 띄워주면 훨씬 더 좋을 것 같습니다.

## 📸 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |

## ☑️ Test Checklist

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #49
