### PR TITLE
[#47] 애플 인증 플로우 구현

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */; };
 		777ECFEC2A26F4490009E302 /* UserDefaults + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777ECFEB2A26F4490009E302 /* UserDefaults + Extension.swift */; };
 		777ECFEF2A2C575B0009E302 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777ECFEE2A2C575B0009E302 /* UserDefault.swift */; };
+		779672AF2A58034E003064A8 /* ASAuthorizationControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779672AE2A58034E003064A8 /* ASAuthorizationControllerProxy.swift */; };
 		77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */; };
 		77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */; };
 		77CB027829D02863006817E5 /* NicknameResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027729D02863006817E5 /* NicknameResponseModel.swift */; };
@@ -157,6 +158,7 @@
 		776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTitleTableViewCell.swift; sourceTree = "<group>"; };
 		777ECFEB2A26F4490009E302 /* UserDefaults + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults + Extension.swift"; sourceTree = "<group>"; };
 		777ECFEE2A2C575B0009E302 /* UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefault.swift; sourceTree = "<group>"; };
+		779672AE2A58034E003064A8 /* ASAuthorizationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerProxy.swift; sourceTree = "<group>"; };
 		77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
 		77CB027729D02863006817E5 /* NicknameResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameResponseModel.swift; sourceTree = "<group>"; };
@@ -379,6 +381,15 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		779672B62A59B019003064A8 /* AppleLogin */ = {
+			isa = PBXGroup;
+			children = (
+				BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */,
+				779672AE2A58034E003064A8 /* ASAuthorizationControllerProxy.swift */,
+			);
+			path = AppleLogin;
+			sourceTree = "<group>";
+		};
 		77A99D672971AFB30037FCAD /* Coordinator */ = {
 			isa = PBXGroup;
 			children = (
@@ -491,7 +502,7 @@
 		BD9AA41629929AB200D4E7CE /* Manager */ = {
 			isa = PBXGroup;
 			children = (
-				BD9AA41729929ABD00D4E7CE /* AppleLoginManager.swift */,
+				779672B62A59B019003064A8 /* AppleLogin */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -1246,6 +1257,7 @@
 				BD90E9E02976C3EF00C7CB6B /* NetworkEnv.swift in Sources */,
 				BD4B550F292A29EC00ECFD04 /* SmokingAreaResponseModel.swift in Sources */,
 				ECA425F6292634C9004DFDAF /* LoginViewModel.swift in Sources */,
+				779672AF2A58034E003064A8 /* ASAuthorizationControllerProxy.swift in Sources */,
 				BD90E9E22976C4F800C7CB6B /* Networking.swift in Sources */,
 				BDE3EEB22A1D124300632662 /* OAuthService.swift in Sources */,
 				77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */; };
 		777ECFEC2A26F4490009E302 /* UserDefaults + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777ECFEB2A26F4490009E302 /* UserDefaults + Extension.swift */; };
 		777ECFEF2A2C575B0009E302 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777ECFEE2A2C575B0009E302 /* UserDefault.swift */; };
+		779672AD2A53D699003064A8 /* AppleOAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779672AC2A53D699003064A8 /* AppleOAuthService.swift */; };
 		779672AF2A58034E003064A8 /* ASAuthorizationControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779672AE2A58034E003064A8 /* ASAuthorizationControllerProxy.swift */; };
 		77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */; };
 		77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */; };
@@ -158,6 +159,7 @@
 		776502172954A3BA002BF7AD /* SettingTitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTitleTableViewCell.swift; sourceTree = "<group>"; };
 		777ECFEB2A26F4490009E302 /* UserDefaults + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults + Extension.swift"; sourceTree = "<group>"; };
 		777ECFEE2A2C575B0009E302 /* UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefault.swift; sourceTree = "<group>"; };
+		779672AC2A53D699003064A8 /* AppleOAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAuthService.swift; sourceTree = "<group>"; };
 		779672AE2A58034E003064A8 /* ASAuthorizationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAuthorizationControllerProxy.swift; sourceTree = "<group>"; };
 		77A99D692971AFDC0037FCAD /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		77A99D6B2971B0220037FCAD /* DefaultSettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingCoordinator.swift; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 		BDE3EEB02A1D10DC00632662 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				779672AC2A53D699003064A8 /* AppleOAuthService.swift */,
 				BD4D62AE2A1A100B00532778 /* KakaoOAuthService.swift */,
 				BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */,
 				BDDAA3962A24BC120055859E /* OAuthProviderType.swift */,
@@ -1242,6 +1245,7 @@
 				BDB6E1FA2A30546D00AE6228 /* Published+Rx.swift in Sources */,
 				ECA425DA29253155004DFDAF /* Coordinator.swift in Sources */,
 				ECA425F4292634A6004DFDAF /* LoginViewController.swift in Sources */,
+				779672AD2A53D699003064A8 /* AppleOAuthService.swift in Sources */,
 				ECA425CF292382AD004DFDAF /* NavigationView.swift in Sources */,
 				77F899DE29308C6000806896 /* FogTextField.swift in Sources */,
 				BDC0D0832A2600D9003D770E /* AuthAPI.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		77CB027829D02863006817E5 /* NicknameResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027729D02863006817E5 /* NicknameResponseModel.swift */; };
 		77CB027B29D02FA1006817E5 /* UserAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027A29D02FA1006817E5 /* UserAPIService.swift */; };
 		77CB027F29DEAE57006817E5 /* RxMoya + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */; };
+		77CB2CC52A5FE59900C68748 /* AppleUserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CB2CC42A5FE59900C68748 /* AppleUserModel.swift */; };
 		77D32D41292A0EDD006E6314 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D40292A0EDD006E6314 /* ViewModelType.swift */; };
 		77D32D43292CD6A3006E6314 /* SideBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D32D42292CD6A2006E6314 /* SideBarView.swift */; };
 		77E70F462930951100F55CD7 /* UITextField + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E70F452930951100F55CD7 /* UITextField + Extension.swift */; };
@@ -166,6 +167,7 @@
 		77CB027729D02863006817E5 /* NicknameResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameResponseModel.swift; sourceTree = "<group>"; };
 		77CB027A29D02FA1006817E5 /* UserAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIService.swift; sourceTree = "<group>"; };
 		77CB027E29DEAE57006817E5 /* RxMoya + Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RxMoya + Extension.swift"; sourceTree = "<group>"; };
+		77CB2CC42A5FE59900C68748 /* AppleUserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleUserModel.swift; sourceTree = "<group>"; };
 		77D32D40292A0EDD006E6314 /* ViewModelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		77D32D42292CD6A2006E6314 /* SideBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarView.swift; sourceTree = "<group>"; };
 		77E70F452930951100F55CD7 /* UITextField + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField + Extension.swift"; sourceTree = "<group>"; };
@@ -416,6 +418,14 @@
 				BDC0D0842A26035D003D770E /* AuthAPIService.swift */,
 			);
 			path = APIServices;
+			sourceTree = "<group>";
+		};
+		77CB2CC32A5FE57400C68748 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				77CB2CC42A5FE59900C68748 /* AppleUserModel.swift */,
+			);
+			path = User;
 			sourceTree = "<group>";
 		};
 		77D32D3F292A0EC7006E6314 /* Protocol */ = {
@@ -669,6 +679,7 @@
 		ECA4255E292251E0004DFDAF /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				77CB2CC32A5FE57400C68748 /* User */,
 				BD5D0D7D29F15E2800190471 /* BottomView */,
 				BD5D0D6E29F12DFF00190471 /* Message */,
 				BD4B550D292A29AA00ECFD04 /* Place */,
@@ -1272,6 +1283,7 @@
 				BDB6E1F52A30383700AE6228 /* NetworkMonitor.swift in Sources */,
 				BDDAA3972A24BC120055859E /* OAuthProviderType.swift in Sources */,
 				BD90E9DC2976C02100C7CB6B /* CommonResponse.swift in Sources */,
+				77CB2CC52A5FE59900C68748 /* AppleUserModel.swift in Sources */,
 				BD347C5A292FD226009F52BA /* ExMapType.swift in Sources */,
 				77F1D82229269CC800F31D0C /* UIColor + Extension.swift in Sources */,
 				777ECFEC2A26F4490009E302 /* UserDefaults + Extension.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/Manager/AppleLogin/ASAuthorizationControllerProxy.swift
+++ b/FogFog-iOS/FogFog-iOS/Manager/AppleLogin/ASAuthorizationControllerProxy.swift
@@ -11,12 +11,10 @@ import AuthenticationServices
 import RxCocoa
 import RxSwift
 
-@available(iOS 13.0, *)
 extension ASAuthorizationController: HasDelegate {
     public typealias Delegate = ASAuthorizationControllerDelegate
 }
 
-@available(iOS 13.0, *)
 class ASAuthorizationControllerProxy: DelegateProxy<ASAuthorizationController, ASAuthorizationControllerDelegate>, DelegateProxyType, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     var presentationWindow: UIWindow = UIWindow()
 
@@ -30,7 +28,7 @@ class ASAuthorizationControllerProxy: DelegateProxy<ASAuthorizationController, A
     }
 
     // MARK: Proxy Subject
-    internal lazy var didComplete = PublishSubject<ASAuthorization>()
+    lazy var didComplete = PublishSubject<ASAuthorization>()
 
     // MARK: ASAuthorizationControllerDelegate
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {

--- a/FogFog-iOS/FogFog-iOS/Manager/AppleLogin/ASAuthorizationControllerProxy.swift
+++ b/FogFog-iOS/FogFog-iOS/Manager/AppleLogin/ASAuthorizationControllerProxy.swift
@@ -1,0 +1,54 @@
+//
+//  ASAuthorizationControllerProxy.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/07/07.
+//
+
+import UIKit
+
+import AuthenticationServices
+import RxCocoa
+import RxSwift
+
+@available(iOS 13.0, *)
+extension ASAuthorizationController: HasDelegate {
+    public typealias Delegate = ASAuthorizationControllerDelegate
+}
+
+@available(iOS 13.0, *)
+class ASAuthorizationControllerProxy: DelegateProxy<ASAuthorizationController, ASAuthorizationControllerDelegate>, DelegateProxyType, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    var presentationWindow: UIWindow = UIWindow()
+
+    public init(controller: ASAuthorizationController) {
+        super.init(parentObject: controller, delegateProxy: ASAuthorizationControllerProxy.self)
+    }
+
+    // MARK: DelegateProxyType
+    public static func registerKnownImplementations() {
+        register { ASAuthorizationControllerProxy(controller: $0) }
+    }
+
+    // MARK: Proxy Subject
+    internal lazy var didComplete = PublishSubject<ASAuthorization>()
+
+    // MARK: ASAuthorizationControllerDelegate
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        didComplete.onNext(authorization)
+        didComplete.onCompleted()
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        didComplete.onCompleted()
+    }
+
+    // MARK: ASAuthorizationControllerPresentationContextProviding
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return presentationWindow
+    }
+
+    // MARK: Completed
+    deinit {
+        self.didComplete.onCompleted()
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Manager/AppleLogin/AppleLoginManager.swift
+++ b/FogFog-iOS/FogFog-iOS/Manager/AppleLogin/AppleLoginManager.swift
@@ -9,30 +9,11 @@ import AuthenticationServices
 import RxCocoa
 import RxSwift
 
-/// AppleUser
-///
-/// - id: 애플 idToken(로그인/회원가입 시 사용)
-/// - email: 이메일
-/// - origin: 애플 원본 Credential
-struct AppleUser {
-    var id: String
-    var code: String
-    var email: String
-}
-
 /// 애플 로그인 매니저
 final class AppleLoginManager: NSObject {
     
-    // 클래스 간 순환 참조 방지
-    private weak var viewController: UIViewController?
-    
     override init() {
         super.init()
-    }
-    
-    convenience init(from viewController: UIViewController) {
-        self.init()
-        self.viewController = viewController
     }
     
     // 로그인 버튼 클릭 시 로직 수행 (request를 보내줄 controller를 생성)

--- a/FogFog-iOS/FogFog-iOS/Models/User/AppleUserModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Models/User/AppleUserModel.swift
@@ -1,0 +1,20 @@
+//
+//  AppleUserModel.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/07/13.
+//
+
+import Foundation
+
+/*
+ 애플 로그인 시 사용되는 유저 데이터
+- id: 애플 idToken(로그인/회원가입 시 사용)
+- code: authorizationCode
+- email: 이메일
+ */
+struct AppleUserModel {
+    var id: String
+    var code: String
+    var email: String
+}

--- a/FogFog-iOS/FogFog-iOS/OAuth/AppleOAuthService.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/AppleOAuthService.swift
@@ -16,19 +16,22 @@ final class AppleOAuthService: OAuthServiceType {
     private let appleLoginManager = AppleLoginManager()
     
     func authorize() -> Single<OAuthAuthentication> {
-        return login().map { OAuthAuthentication(oauthType: .apple, idToken: $0.id, code: $0.code)}
+        return login().map { OAuthAuthentication(oauthType: .apple, idToken: $0.id, code: $0.code) }
     }
     
-    private func login() -> Single<AppleUser> {
+    private func login() -> Single<AppleUserModel> {
         return Single.create { observer in
             self.appleLoginManager
                 .handleAuthorizationAppleIDButtonPress()
                 .subscribe(onNext: { result in
-                    guard let auth = result.credential as? ASAuthorizationAppleIDCredential else { return }
-                    let idToken = String(decoding: auth.identityToken!, as: UTF8.self)
-                    let code = String(decoding: auth.authorizationCode!, as: UTF8.self)
-                    let appleUser = AppleUser(id: idToken,
-                                              code: code,
+                    guard
+                        let auth = result.credential as? ASAuthorizationAppleIDCredential,
+                        let idToken = auth.identityToken,
+                        let code = auth.authorizationCode
+                    else { return }
+                    
+                    let appleUser = AppleUserModel(id: String(decoding: idToken, as: UTF8.self),
+                                              code: String(decoding: code, as: UTF8.self),
                                               email: auth.email ?? "")
                     observer(.success(appleUser))
                 }, onError: { error in

--- a/FogFog-iOS/FogFog-iOS/OAuth/AppleOAuthService.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/AppleOAuthService.swift
@@ -1,0 +1,42 @@
+//
+//  AppleOAuthService.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/07/04.
+//
+
+import UIKit
+
+import AuthenticationServices
+import RxSwift
+
+final class AppleOAuthService: OAuthServiceType {
+    
+    private let disposeBag = DisposeBag()
+    private let appleLoginManager = AppleLoginManager()
+    
+    func authorize() -> Single<OAuthAuthentication> {
+        return login().map { OAuthAuthentication(oauthType: .apple, idToken: $0.id, code: $0.code)}
+    }
+    
+    private func login() -> Single<AppleUser> {
+        return Single.create { observer in
+            self.appleLoginManager
+                .handleAuthorizationAppleIDButtonPress()
+                .subscribe(onNext: { result in
+                    guard let auth = result.credential as? ASAuthorizationAppleIDCredential else { return }
+                    let idToken = String(decoding: auth.identityToken!, as: UTF8.self)
+                    let code = String(decoding: auth.authorizationCode!, as: UTF8.self)
+                    let appleUser = AppleUser(id: idToken,
+                                              code: code,
+                                              email: auth.email ?? "")
+                    observer(.success(appleUser))
+                }, onError: { error in
+                    observer(.failure(error))
+                })
+                .disposed(by: self.disposeBag)
+            
+            return Disposables.create()
+        }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthProviderType.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthProviderType.swift
@@ -20,8 +20,8 @@ enum OAuthProviderType: String, Hashable, CaseIterable {
         switch self {
         case .kakao:
             return KakaoOAuthService()
-        default:
-            return KakaoOAuthService()
+        case .apple:
+            return AppleOAuthService()
         }
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewController/LoginViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewController/LoginViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import AuthenticationServices
 import RxSwift
 
 final class LoginViewController: BaseViewController {
@@ -40,14 +41,7 @@ final class LoginViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let input = LoginViewModel.Input(kakaoButtonDidTap: kakaoButton.rx.tap.asObservable())
-        let output = viewModel.transform(input: input)
-        
-        output.loginResult
-            .drive { msg in
-                print("로그인 메시지 \(msg)")
-            }
-            .disposed(by: disposeBag)
+        bind()
     }
     
     // MARK: UI
@@ -183,5 +177,21 @@ final class LoginViewController: BaseViewController {
             $0.height.equalTo(54)
             $0.bottom.equalToSuperview().inset(70)
         }
+    }
+}
+
+// MARK: - Bind
+extension LoginViewController {
+    
+    private func bind() {
+        let input = LoginViewModel.Input(kakaoButtonDidTap: kakaoButton.rx.tap.asObservable(),
+                                         appleButtonDidTap: appleButton.rx.tap.asObservable())
+        let output = viewModel.transform(input: input)
+
+        output.loginResult
+            .drive { msg in
+                print("로그인 메시지 \(msg)")
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -14,6 +14,7 @@ final class LoginViewModel: ViewModelType {
 
     struct Input {
         let kakaoButtonDidTap: Observable<Void>
+        let appleButtonDidTap: Observable<Void>
     }
     
     struct Output {
@@ -42,6 +43,15 @@ final class LoginViewModel: ViewModelType {
         
         input.kakaoButtonDidTap
             .flatMap(loginWithKakao)
+            .subscribe { _ in
+                result.onNext("success!")
+            } onError: { error in
+                result.onNext("error: \(error.localizedDescription)")
+            }
+            .disposed(by: disposeBag)
+        
+        input.appleButtonDidTap
+            .flatMap(loginWithApple)
             .subscribe { _ in
                 result.onNext("success!")
             } onError: { error in


### PR DESCRIPTION
## 🔍 What is this PR?
애플 로그인을 위한 인증 플로우를 구현했습니다.

## 📝 Changes
### AppleOAuthService 부분 구현
![241954596-e70f40db-6151-40d0-9ebf-da79bc2137a8](https://github.com/TeamFogFog/FogFog-iOS/assets/63277563/0c8edd5c-cdc1-4f4a-a085-f55a577b4f83)
태끼가 인증 로직을 너무 잘 짜놓아서 제가 한 것은 `AppleOAuthService` 부분 구현밖에 없습니다..ㅎ @Taehyeon-Kim 태끼 짱

`OAuthService` 에서 애플/카카오 인증 결과를 반환하고 이 값을 이용해 `AuthService` 에서 포그포그 자체 서버 인증을 진행하게 되는데,
이 구조에 맞춰 애플 인증 로직을 구현하기 위해 `AppleOAuthService`에서 애플 인증 성공 시 결과 값을 받을 수 있도록(subscribe하고 있다가) 인증 결과를 Observable 스트림으로 반환하는 형태로 기존 `AppleLoginManager` 파일을 리팩토링했습니다.


## ☑️ Test Checklist
- [x] 애플 인증 성공 확인
- [x] 애플 인증 후 자체 서버 회원가입/로그인 성공 확인

로그인/회원가입 로직 todo
- [ ] 자동로그인 여부 저장
- [ ] 로그인/회원가입 완료 후 화면 전환
- [ ] 토큰 만료 시 갱신 

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #47 
