### PR TITLE
[#44] 지도 권한 로직 개선

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -1503,9 +1503,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "FogFog-iOS/FogFog-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 397WA8BG8W;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 397WA8BG8W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FogFog-iOS/Supports/Info.plist";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 체크";
@@ -1541,9 +1543,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "FogFog-iOS/FogFog-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 397WA8BG8W;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 397WA8BG8W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "FogFog-iOS/Supports/Info.plist";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 체크";

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -80,7 +80,6 @@
 		BDC0D0852A26035D003D770E /* AuthAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC0D0842A26035D003D770E /* AuthAPIService.swift */; };
 		BDC20F9A293B446D00B9A2E7 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */; };
 		BDC20F9D293B44B600B9A2E7 /* FogToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F9C293B44B600B9A2E7 /* FogToast.swift */; };
-		BDC50ECB292A07B2002378C6 /* GoogleMap.plist in Resources */ = {isa = PBXBuildFile; fileRef = BDC50ECA292A07B2002378C6 /* GoogleMap.plist */; };
 		BDC50ED2292A07EB002378C6 /* SmokingAreaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */; };
 		BDC50ED6292A09BD002378C6 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED5292A09BD002378C6 /* BaseView.swift */; };
 		BDDAA3912A249D090055859E /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3902A249D090055859E /* Config.swift */; };
@@ -89,6 +88,10 @@
 		BDDAA3972A24BC120055859E /* OAuthProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3962A24BC120055859E /* OAuthProviderType.swift */; };
 		BDE3EEB22A1D124300632662 /* OAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE3EEB12A1D124300632662 /* OAuthService.swift */; };
 		BDEA50D129261C6600110982 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = BDEA50D029261C6600110982 /* .swiftlint.yml */; };
+		EC15622D2A6D77F500163875 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EC15622C2A6D77F500163875 /* Config.xcconfig */; };
+		EC15622F2A6D78C800163875 /* GoogleMap.plist in Resources */ = {isa = PBXBuildFile; fileRef = EC15622E2A6D78C800163875 /* GoogleMap.plist */; };
+		EC1562312A6D7D8200163875 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1562302A6D7D8200163875 /* LocationService.swift */; };
+		EC1562332A6D7D8A00163875 /* DefaultLoactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1562322A6D7D8A00163875 /* DefaultLoactionService.swift */; };
 		ECA4252D29224DB8004DFDAF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4252C29224DB8004DFDAF /* AppDelegate.swift */; };
 		ECA4252F29224DB8004DFDAF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA4252E29224DB8004DFDAF /* SceneDelegate.swift */; };
 		ECA4253629224DBB004DFDAF /* Asset.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ECA4253529224DBB004DFDAF /* Asset.xcassets */; };
@@ -209,10 +212,8 @@
 		BDC0D0842A26035D003D770E /* AuthAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPIService.swift; sourceTree = "<group>"; };
 		BDC20F99293B446D00B9A2E7 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		BDC20F9C293B44B600B9A2E7 /* FogToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogToast.swift; sourceTree = "<group>"; };
-		BDC50ECA292A07B2002378C6 /* GoogleMap.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
 		BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokingAreaDetailViewModel.swift; sourceTree = "<group>"; };
 		BDC50ED5292A09BD002378C6 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
-		BDDAA38F2A249B550055859E /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		BDDAA3902A249D090055859E /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		BDDAA3922A24B9D00055859E /* OAuthServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthServiceType.swift; sourceTree = "<group>"; };
 		BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthentication.swift; sourceTree = "<group>"; };
@@ -221,6 +222,10 @@
 		BDEA50D029261C6600110982 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D67B489E657987D4A7AD92C7 /* Pods_FogFog_iOS_FogFog_iOSUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FogFog_iOS_FogFog_iOSUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DABD884BD50346C82E3C3CA3 /* Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOS-FogFog-iOSUITests/Pods-FogFog-iOS-FogFog-iOSUITests.release.xcconfig"; sourceTree = "<group>"; };
+		EC15622C2A6D77F500163875 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		EC15622E2A6D78C800163875 /* GoogleMap.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleMap.plist; sourceTree = "<group>"; };
+		EC1562302A6D7D8200163875 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
+		EC1562322A6D7D8A00163875 /* DefaultLoactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLoactionService.swift; sourceTree = "<group>"; };
 		ECA4252929224DB8004DFDAF /* FogFog-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "FogFog-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECA4252C29224DB8004DFDAF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		ECA4252E29224DB8004DFDAF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -716,8 +721,8 @@
 			isa = PBXGroup;
 			children = (
 				ECA4253A29224DBB004DFDAF /* Info.plist */,
-				BDC50ECA292A07B2002378C6 /* GoogleMap.plist */,
-				BDDAA38F2A249B550055859E /* Config.xcconfig */,
+				EC15622C2A6D77F500163875 /* Config.xcconfig */,
+				EC15622E2A6D78C800163875 /* GoogleMap.plist */,
 			);
 			path = Supports;
 			sourceTree = "<group>";
@@ -799,6 +804,8 @@
 				ECA425772922545C004DFDAF /* MapViewController.swift */,
 				ECA425CE292382AD004DFDAF /* NavigationView.swift */,
 				ECA425EB29262CF7004DFDAF /* MapViewModel.swift */,
+				EC1562302A6D7D8200163875 /* LocationService.swift */,
+				EC1562322A6D7D8A00163875 /* DefaultLoactionService.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -1081,15 +1088,16 @@
 			files = (
 				BDEA50D129261C6600110982 /* .swiftlint.yml in Resources */,
 				77F1D8262926AAD600F31D0C /* Pretendard-Bold.otf in Resources */,
+				EC15622F2A6D78C800163875 /* GoogleMap.plist in Resources */,
 				77F1D8282926AADB00F31D0C /* Pretendard-ExtraLight.otf in Resources */,
 				77F1D8272926AAD900F31D0C /* Pretendard-ExtraBold.otf in Resources */,
+				EC15622D2A6D77F500163875 /* Config.xcconfig in Resources */,
 				77F1D82B2926AAE200F31D0C /* Pretendard-Regular.otf in Resources */,
 				77F1D82D2926AAE800F31D0C /* Pretendard-Thin.otf in Resources */,
 				77F1D8292926AADD00F31D0C /* Pretendard-Light.otf in Resources */,
 				ECA4253929224DBB004DFDAF /* LaunchScreen.storyboard in Resources */,
 				ECA425742922543B004DFDAF /* Color.xcassets in Resources */,
 				77F1D82C2926AAE500F31D0C /* Pretendard-SemiBold.otf in Resources */,
-				BDC50ECB292A07B2002378C6 /* GoogleMap.plist in Resources */,
 				ECA4257229225409004DFDAF /* Image.xcassets in Resources */,
 				77F1D8252926AAD300F31D0C /* Pretendard-Black.otf in Resources */,
 				ECA4253629224DBB004DFDAF /* Asset.xcassets in Resources */,
@@ -1272,6 +1280,7 @@
 				BD90E9E02976C3EF00C7CB6B /* NetworkEnv.swift in Sources */,
 				BD4B550F292A29EC00ECFD04 /* SmokingAreaResponseModel.swift in Sources */,
 				ECA425F6292634C9004DFDAF /* LoginViewModel.swift in Sources */,
+				EC1562312A6D7D8200163875 /* LocationService.swift in Sources */,
 				779672AF2A58034E003064A8 /* ASAuthorizationControllerProxy.swift in Sources */,
 				BD90E9E22976C4F800C7CB6B /* Networking.swift in Sources */,
 				BDE3EEB22A1D124300632662 /* OAuthService.swift in Sources */,
@@ -1319,6 +1328,7 @@
 				ECA425782922545C004DFDAF /* MapViewController.swift in Sources */,
 				BD347C63292FEA15009F52BA /* RoadPopUpView.swift in Sources */,
 				ECA425D72924DA66004DFDAF /* Bundle + Extension.swift in Sources */,
+				EC1562332A6D7D8A00163875 /* DefaultLoactionService.swift in Sources */,
 				BD5D0D7429F1302F00190471 /* Presentable.swift in Sources */,
 				BDC20F9D293B44B600B9A2E7 /* FogToast.swift in Sources */,
 				BD5D0D7629F1310800190471 /* SmokingAreaCardView.swift in Sources */,
@@ -1373,7 +1383,6 @@
 /* Begin XCBuildConfiguration section */
 		ECA4255129224DBB004DFDAF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BDDAA38F2A249B550055859E /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1434,7 +1443,6 @@
 		};
 		ECA4255229224DBB004DFDAF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BDDAA38F2A249B550055859E /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/DefaultMapCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/DefaultMapCoordinator.swift
@@ -23,7 +23,7 @@ final class DefaultMapCoordinator: MapCoordinator {
     }
 
     func showMapViewController() {
-        let mapViewModel = MapViewModel(coordinator: self)
+        let mapViewModel = MapViewModel(coordinator: self, locationService: DefaultLocationService())
         let mapViewController = MapViewController(viewModel: mapViewModel)
         changeAnimation()
         navigationController.viewControllers = [mapViewController]

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/DefaultLoactionService.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/DefaultLoactionService.swift
@@ -1,0 +1,65 @@
+//
+//  DefaultLocationService.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2023/07/24.
+//
+
+import CoreLocation
+import Foundation
+
+import RxSwift
+import RxRelay
+
+final class DefaultLocationService: NSObject, LocationService {
+    
+    var locationManager: CLLocationManager?
+    var disposeBag: DisposeBag = DisposeBag()
+    var authorizationStatus = BehaviorRelay<CLAuthorizationStatus>(value: .notDetermined)
+    
+    override init() {
+        super.init()
+        self.locationManager = CLLocationManager()
+        self.locationManager?.distanceFilter = CLLocationDistance(3)
+        self.locationManager?.delegate = self
+        self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
+    }
+    
+    func start() {
+        self.locationManager?.startUpdatingLocation()
+    }
+    
+    func stop() {
+        self.locationManager?.stopUpdatingLocation()
+    }
+    
+    func requestAuthorization() {
+        self.locationManager?.requestWhenInUseAuthorization()
+    }
+    
+    func observeUpdatedAuthorization() -> Observable<CLAuthorizationStatus> {
+        return self.authorizationStatus.asObservable()
+    }
+    
+    func observeUpdatedLocation() -> Observable<[CLLocation]> {
+        return PublishRelay<[CLLocation]>.create({ emitter in
+            self.rx.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
+                .compactMap({ $0.last as? [CLLocation] })
+                .subscribe(onNext: { location in
+                    emitter.onNext(location)
+                })
+                .disposed(by: self.disposeBag)
+            return Disposables.create()
+        })
+    }
+}
+
+extension DefaultLocationService: CLLocationManagerDelegate {
+    func locationManager(
+        _ manager: CLLocationManager,
+        didUpdateLocations locations: [CLLocation]) {}
+    
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        self.authorizationStatus.accept(status)
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/LocationService.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/LocationService.swift
@@ -1,0 +1,21 @@
+//
+//  LocationService.swift
+//  FogFog-iOS
+//
+//  Created by 김승찬 on 2023/07/24.
+//
+
+import CoreLocation
+import Foundation
+
+import RxSwift
+import RxRelay
+
+protocol LocationService {
+    var authorizationStatus: BehaviorRelay<CLAuthorizationStatus> { get set }
+    func start()
+    func stop()
+    func requestAuthorization()
+    func observeUpdatedAuthorization() -> Observable<CLAuthorizationStatus>
+    func observeUpdatedLocation() -> Observable<[CLLocation]>
+}

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -91,7 +91,7 @@ extension MapViewController {
     private func bind() {
         let input = MapViewModel.Input(
             viewDidLoad: Signal<Void>.just(()),
-            tapMenuButton: navigationView.menuButtonObservable,
+            tapMenuButton: navigationView.rx.menuButtonTapped,
             tapBlurEffectView: tapBlurEffectView.asSignal(),
             tapSettingButton: sideBarView.settingButtonDidTap())
         let output = viewModel.transform(input: input)
@@ -115,8 +115,8 @@ extension MapViewController {
         
         output.currentUserLocation
             .asDriver()
-            .drive { coordinator in
-                self.move(at: coordinator)
+            .drive { coordinates in
+                self.move(at: coordinates)
             }
             .disposed(by: disposeBag)
     }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -20,11 +20,9 @@ final class MapViewController: BaseViewController {
     private lazy var navigationView = NavigationView()
     private lazy var sideBarView = SideBarView()
     private var blurEffectView: UIVisualEffectView!
-    private let camera = GMSCameraPosition(latitude: 37.54330366639085, longitude: 127.04455548501139, zoom: 12)
+   
     private var mapView = GMSMapView()
     private var myMarker = GMSMarker()
-    private var locationManager = CLLocationManager()
-    private var currentLocation: CLLocation!
     
     private var viewModel: MapViewModel
     private let tapBlurEffectView = PublishRelay<Void>()
@@ -47,14 +45,14 @@ final class MapViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        assignDelegation()
+
+        makeMarker()
         bind()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-     
+        
         setLocation()
     }
     
@@ -93,7 +91,7 @@ extension MapViewController {
     private func bind() {
         let input = MapViewModel.Input(
             viewDidLoad: Signal<Void>.just(()),
-            tapMenuButton: navigationView.menuButton.rx.tap.asSignal(),
+            tapMenuButton: navigationView.menuButtonObservable,
             tapBlurEffectView: tapBlurEffectView.asSignal(),
             tapSettingButton: sideBarView.settingButtonDidTap())
         let output = viewModel.transform(input: input)
@@ -114,21 +112,17 @@ extension MapViewController {
                 self.sideBarView.nicknameLabel.text = result
             })
             .disposed(by: disposeBag)
+        
+        output.currentUserLocation
+            .asDriver()
+            .drive { coordinator in
+                self.move(at: coordinator)
+            }
+            .disposed(by: disposeBag)
     }
 }
-
 // MARK: - Custom Methods
 extension MapViewController {
-    
-    private func assignDelegation() {
-        locationManager.delegate = self
-    }
-    
-    private func setLocation() {
-        mapView.isMyLocationEnabled = true
-        locationManager.startUpdatingLocation()
-        move(at: locationManager.location?.coordinate)
-    }
     
     private func setSideBarViewLayout(isVisible: Bool = false) {
         blurEffectView.isHidden = !isVisible
@@ -154,60 +148,16 @@ extension MapViewController {
     }
 }
 
-// MARK: - CLLocationManagerDelegate
-extension MapViewController: CLLocationManagerDelegate {
-    
-    func checkCurrentLocationAuthorization(authorizationStatus: CLAuthorizationStatus) {
-        switch authorizationStatus {
-        case .notDetermined:
-            print("notDetermined")
-        case .restricted, .denied:
-            print("restricted")
-        case .authorizedAlways, .authorizedWhenInUse:
-            print("authorizedAlways")
-        @unknown default:
-            print("unknown")
-        }
-        
-        if #available(iOS 14.0, *) {
-            let accuracyState = locationManager.accuracyAuthorization
-            switch accuracyState {
-            case .fullAccuracy:
-                print("full")
-            case .reducedAccuracy:
-                print("reduced")
-            @unknown default:
-                print("Unknown")
-            }
-        }
+private extension MapViewController {
+    func setLocation() {
+        mapView.isMyLocationEnabled = true
     }
     
-    func checkUserLocationServicesAuthorization() {
-        // iOS 14부터는 정확도 설정이 들어감
-        // 시스템 설정을 다르게 해줌
-        let authorizationStatus: CLAuthorizationStatus
-        
-        if #available(iOS 14, *) {
-            authorizationStatus = locationManager.authorizationStatus
-        } else {
-            authorizationStatus = CLLocationManager.authorizationStatus()
-        }
-        
-        if CLLocationManager.locationServicesEnabled() {
-            checkCurrentLocationAuthorization(authorizationStatus: authorizationStatus)
-        } else {
-            print("위치 권한 켜주세요")
-        }
-    }
-    
-    // iOS14 이상: 앱이 위치 관리자를 생성하고, 승인 상태가 변경이 될 때 대리자에게 승인 상태를 알려줌
-    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        checkUserLocationServicesAuthorization()
-    }
-    
-    // iOS14 미만: 앱이 위치 관리자를 생성하고, 승인 상태가 변경이 될 때 대리자에게 승인 상태를 알려줌
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        checkUserLocationServicesAuthorization()
+    func makeMarker() {
+        let mapCenter = CLLocationCoordinate2DMake(37.57039821, 126.98914393)
+        let marker = GMSMarker(position: mapCenter)
+        marker.icon = FogImage.placeMarker
+        marker.map = mapView
     }
     
     func distance(from: CLLocationCoordinate2D) -> CLLocationDistance {

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -32,7 +32,7 @@ final class MapViewModel: ViewModelType {
     
     struct Input {
         let viewDidLoad: Signal<Void>
-        let tapMenuButton: Observable<Void>
+        let tapMenuButton: ControlEvent<Void>
         let tapBlurEffectView: Signal<Void>
         let tapSettingButton: Signal<Void>
     }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/NavigationView.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/NavigationView.swift
@@ -7,13 +7,20 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
 import SnapKit
 import Then
 
 final class NavigationView: UIView {
     
     private lazy var logoImageView = UIImageView()
-    lazy var menuButton = UIButton()
+    private let menuButtonTapped = PublishSubject<Void>()
+    private lazy var menuButton = UIButton(frame: .zero,
+                                           primaryAction: UIAction(handler: { [weak self] _ in
+        guard let self else { return }
+          self.menuButtonTapped.onNext(())
+    }))
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -58,5 +65,11 @@ final class NavigationView: UIView {
             $0.centerY.equalTo(logoImageView.snp.centerY)
             $0.size.equalTo(30)
         }
+    }
+}
+
+extension NavigationView {
+    public var menuButtonObservable: Observable<Void> {
+        return menuButtonTapped.asObservable()
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/NavigationView.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/NavigationView.swift
@@ -15,12 +15,7 @@ import Then
 final class NavigationView: UIView {
     
     private lazy var logoImageView = UIImageView()
-    private let menuButtonTapped = PublishSubject<Void>()
-    private lazy var menuButton = UIButton(frame: .zero,
-                                           primaryAction: UIAction(handler: { [weak self] _ in
-        guard let self else { return }
-          self.menuButtonTapped.onNext(())
-    }))
+    fileprivate lazy var menuButton = UIButton()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -68,8 +63,8 @@ final class NavigationView: UIView {
     }
 }
 
-extension NavigationView {
-    public var menuButtonObservable: Observable<Void> {
-        return menuButtonTapped.asObservable()
+extension Reactive where Base: NavigationView {
+    var menuButtonTapped: ControlEvent<Void> {
+        base.menuButton.rx.tap
     }
 }


### PR DESCRIPTION
## 🔍 What is this PR?
기존에는 `MapViewController`에서 지도 권한 설정, 현재 위치 등에 대한 로직들을 처리하고 있었습니다.
이를 `DefaultLocationService` 객체를 만들어 지도 권한 설정 및 현재 위치 등 그에 따들을 기능들을 다루고 `MapViewModel`에서 처리를 할 수 있게 수정하였습니다.

## 📝 Changes
### 1. LocationService
LocationService 프로토콜입니다. 
```swift
protocol LocationService {
    var authorizationStatus: BehaviorRelay<CLAuthorizationStatus> { get set }
    func start()
    func stop()
    func requestAuthorization()
    func observeUpdatedAuthorization() -> Observable<CLAuthorizationStatus>
    func observeUpdatedLocation() -> Observable<[CLLocation]>
}
```
헤딩 기능의 실체 구현은 DefaultLoactionService에서 구현합니다.
현재 MapViewController에서 GoogleMaps에 관한 UI를 처리하고 있는데 이 부분 또한 MapViewModel에서 위도, 경도값만 받을 수 있게 로직을 개선할 예정입니다.

### 2. View, ViewController 분리
기존 MapViewController에 있는 MapViewModel.Input의 코드는 다음과 같습니다.
```swift
tapMenuButton: navigationView.menuButtonObservable
```
NavigationView에 있는 menuButton에 액션을 주기 위해 접근제어자를 풀고 직접 접근을 하는 구조입니다.
이에 대한 고민이 많았는데 다음과 같이 menuButtonObservable을 통해 버튼에 대한 액션을 처리할 수 있게 수정했습니다.

```
 private let menuButtonTapped = PublishSubject<Void>()
    private lazy var menuButton = UIButton(frame: .zero,
                                           primaryAction: UIAction(handler: { [weak self] _ in
        guard let self else { return }
          self.menuButtonTapped.onNext(())
    }))


extension NavigationView {
    public var menuButtonObservable: Observable<Void> {
        return menuButtonTapped.asObservable()
    }
}
```

## 📸 Screenshot
`생략`

## ☑️ Test Checklist

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #44 
