### PR TITLE
[#54] 토큰 갱신 로직 구현

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		772577DC2934924E008273A7 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 772577DB2934924E008273A7 /* RxGesture */; };
 		775AC1972A735FE800A2A47E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775AC1962A735FE800A2A47E /* Keychain.swift */; };
 		775AC1992A7369C800A2A47E /* Keychain + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775AC1982A7369C800A2A47E /* Keychain + Extension.swift */; };
+		775DB3752A8F40E800214C8F /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775DB3742A8F40E800214C8F /* AuthInterceptor.swift */; };
 		775DB37B2A91D65000214C8F /* ReissueAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775DB37A2A91D65000214C8F /* ReissueAPIService.swift */; };
 		7761D4F4292F3471003971DC /* MakeNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7761D4F3292F3471003971DC /* MakeNicknameViewController.swift */; };
 		7761D4F6292F3749003971DC /* FogNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7761D4F5292F3749003971DC /* FogNavigationView.swift */; };
@@ -161,6 +162,7 @@
 		568E5A05A08D8D049D3D8E62 /* Pods-FogFog-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOSTests/Pods-FogFog-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		775AC1962A735FE800A2A47E /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		775AC1982A7369C800A2A47E /* Keychain + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain + Extension.swift"; sourceTree = "<group>"; };
+		775DB3742A8F40E800214C8F /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		775DB37A2A91D65000214C8F /* ReissueAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissueAPIService.swift; sourceTree = "<group>"; };
 		7761D4F3292F3471003971DC /* MakeNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeNicknameViewController.swift; sourceTree = "<group>"; };
 		7761D4F5292F3749003971DC /* FogNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogNavigationView.swift; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 				BD90E9DF2976C3EF00C7CB6B /* NetworkEnv.swift */,
 				BD4E13642973DAC400AEA757 /* NetworkError.swift */,
 				BD90E9E12976C4F800C7CB6B /* Networking.swift */,
+				775DB3742A8F40E800214C8F /* AuthInterceptor.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1287,6 +1290,7 @@
 				77C3C1682A7AB3150079AF4C /* MakeNicknameViewType.swift in Sources */,
 				BD5D0D7C29F14FDC00190471 /* SmokingAreaMessageView.swift in Sources */,
 				77650216295487A7002BF7AD /* SettingNicknameTableViewCell.swift in Sources */,
+				775DB3752A8F40E800214C8F /* AuthInterceptor.swift in Sources */,
 				77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */,
 				BD4572142A8A404D009E9B3C /* EmptyData.swift in Sources */,
 				BD4D62AF2A1A100B00532778 /* KakaoOAuthService.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		772577DC2934924E008273A7 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 772577DB2934924E008273A7 /* RxGesture */; };
 		775AC1972A735FE800A2A47E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775AC1962A735FE800A2A47E /* Keychain.swift */; };
 		775AC1992A7369C800A2A47E /* Keychain + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775AC1982A7369C800A2A47E /* Keychain + Extension.swift */; };
+		775DB37B2A91D65000214C8F /* ReissueAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775DB37A2A91D65000214C8F /* ReissueAPIService.swift */; };
 		7761D4F4292F3471003971DC /* MakeNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7761D4F3292F3471003971DC /* MakeNicknameViewController.swift */; };
 		7761D4F6292F3749003971DC /* FogNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7761D4F5292F3749003971DC /* FogNavigationView.swift */; };
 		77650202295448AE002BF7AD /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77650201295448AE002BF7AD /* SettingViewController.swift */; };
@@ -160,6 +161,7 @@
 		568E5A05A08D8D049D3D8E62 /* Pods-FogFog-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOSTests/Pods-FogFog-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		775AC1962A735FE800A2A47E /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		775AC1982A7369C800A2A47E /* Keychain + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain + Extension.swift"; sourceTree = "<group>"; };
+		775DB37A2A91D65000214C8F /* ReissueAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReissueAPIService.swift; sourceTree = "<group>"; };
 		7761D4F3292F3471003971DC /* MakeNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeNicknameViewController.swift; sourceTree = "<group>"; };
 		7761D4F5292F3749003971DC /* FogNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogNavigationView.swift; sourceTree = "<group>"; };
 		77650201295448AE002BF7AD /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 			children = (
 				77CB027A29D02FA1006817E5 /* UserAPIService.swift */,
 				BDC0D0842A26035D003D770E /* AuthAPIService.swift */,
+				775DB37A2A91D65000214C8F /* ReissueAPIService.swift */,
 			);
 			path = APIServices;
 			sourceTree = "<group>";
@@ -1347,6 +1350,7 @@
 				776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */,
 				ECA425EC29262CF8004DFDAF /* MapViewModel.swift in Sources */,
 				7761D4F4292F3471003971DC /* MakeNicknameViewController.swift in Sources */,
+				775DB37B2A91D65000214C8F /* ReissueAPIService.swift in Sources */,
 				77D32D43292CD6A3006E6314 /* SideBarView.swift in Sources */,
 				BD347C60292FD4C8009F52BA /* FogButton.swift in Sources */,
 				ECA4257E292254C6004DFDAF /* BaseViewController.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/AuthAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/AuthAPIService.swift
@@ -18,20 +18,16 @@ protocol AuthAPIServiceType {
 final class AuthAPIService: Networking, AuthAPIServiceType {
     
     // MARK: - Type Alias
-    
     typealias API = AuthAPI
     
     // MARK: - Rx
-    
     private let disposeBag = DisposeBag()
     
     // MARK: - Property
-    
     private let provider = NetworkProvider<API>()
     private var oauthService: OAuthServiceType
     
     // MARK: - Initialization
-    
     init(oauthService: OAuthServiceType) {
         self.oauthService = oauthService
     }

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -1,0 +1,35 @@
+//
+//  ReissueAPIService.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/08/20.
+//
+
+import Foundation
+
+import Moya
+import RxCocoa
+import RxSwift
+
+final class ReissueAPIService: Networking {
+
+    // MARK: Type Alias
+    typealias API = AuthAPI
+    
+    // MARK: Property
+    private let provider = NetworkProvider<API>()
+    
+    // MARK: Instance
+    static let shared = ReissueAPIService()
+    
+    // MARK: Initialization
+    private init() {}
+    
+    // 401 error 시 토큰 재발급 Request
+    func reissueAuthentication() -> Single<SignInResponseDTO?> {
+        return provider
+            .request(.reissueToken)
+            .map(SignInResponseDTO.self)
+    }
+}
+

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -19,6 +19,12 @@ final class ReissueAPIService: Networking {
     // MARK: - Property
     private let provider = NetworkProvider<API>()
     
+    // MARK: - Instance
+    static let shared = ReissueAPIService()
+    
+    // MARK: - Initialization
+    private init() {}
+    
     // MARK: - Custom Methods
     
     // 401 error 시 토큰 재발급 Request

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -11,11 +11,7 @@ import Moya
 import RxCocoa
 import RxSwift
 
-protocol Reissueable {
-    func reissueAuthentication() -> Single<SignInResponseDTO?>
-}
-
-final class ReissueAPIService: Networking, Reissueable {
+final class ReissueAPIService: Networking {
 
     // MARK: - Type Alias
     typealias API = AuthAPI

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -19,12 +19,6 @@ final class ReissueAPIService: Networking {
     // MARK: - Property
     private let provider = NetworkProvider<API>()
     
-    // MARK: - Instance
-    static let shared = ReissueAPIService()
-    
-    // MARK: - Initialization
-    private init() {}
-    
     // MARK: - Custom Methods
     
     // 401 error 시 토큰 재발급 Request

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -13,17 +13,19 @@ import RxSwift
 
 final class ReissueAPIService: Networking {
 
-    // MARK: Type Alias
+    // MARK: - Type Alias
     typealias API = AuthAPI
     
-    // MARK: Property
+    // MARK: - Property
     private let provider = NetworkProvider<API>()
     
-    // MARK: Instance
+    // MARK: - Instance
     static let shared = ReissueAPIService()
     
-    // MARK: Initialization
+    // MARK: - Initialization
     private init() {}
+    
+    // MARK: - Custom Methods
     
     // 401 error 시 토큰 재발급 Request
     func reissueAuthentication() -> Single<SignInResponseDTO?> {
@@ -32,4 +34,3 @@ final class ReissueAPIService: Networking {
             .map(SignInResponseDTO.self)
     }
 }
-

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -11,7 +11,11 @@ import Moya
 import RxCocoa
 import RxSwift
 
-final class ReissueAPIService: Networking {
+protocol Reissueable {
+    func reissueAuthentication() -> Single<SignInResponseDTO?>
+}
+
+final class ReissueAPIService: Networking, Reissueable {
 
     // MARK: - Type Alias
     typealias API = AuthAPI

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/UserAPIService.swift
@@ -12,12 +12,20 @@ import RxCocoa
 import RxSwift
 
 class UserAPIService: Networking {
+    
+    // MARK: - Type Alias
     typealias API = UserAPI
     
-    static let shared = UserAPIService()
-    var provider = NetworkProvider<API>()
+    // MARK: - Property
+    private let provider = NetworkProvider<API>()
     
+    // MARK: - Instance
+    static let shared = UserAPIService()
+    
+    // MARK: - Initialization
     private init() {}
+    
+    // MARK: - Custom Methods
     
     // 유저 닉네임 조회
     func getUserNickname(userId: Int) -> Single<NicknameResponseModel?> {

--- a/FogFog-iOS/FogFog-iOS/Networking/APIs/AuthAPI.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIs/AuthAPI.swift
@@ -17,11 +17,12 @@ struct SignInRequestDTO: Codable {
 struct SignInResponseDTO: Codable {
     let accessToken: String
     let refreshToken: String
-    let id: Int
+    let id: Int?
 }
 
 enum AuthAPI {
     case signIn(request: SignInRequestDTO)
+    case reissueToken
 }
 
 extension AuthAPI: FogAPI {
@@ -34,6 +35,8 @@ extension AuthAPI: FogAPI {
         switch self {
         case .signIn:
             return "/signin"
+        case .reissueToken:
+            return "/reissue/token"
         }
     }
     
@@ -41,6 +44,8 @@ extension AuthAPI: FogAPI {
         switch self {
         case .signIn:
             return .post
+        case .reissueToken:
+            return .get
         }
     }
     
@@ -53,12 +58,14 @@ extension AuthAPI: FogAPI {
                 "idToken": request.idToken ?? "",
                 "code": request.code ?? ""
             ]
+        case .reissueToken:
+            return nil
         }
     }
     
     var error: [Int: NetworkError]? {
         switch self {
-        case .signIn:
+        case .signIn, .reissueToken:
             return nil
         }
     }

--- a/FogFog-iOS/FogFog-iOS/Networking/APIs/FogAPI.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIs/FogAPI.swift
@@ -57,10 +57,7 @@ extension FogAPI {
     }
     
     var headers: [String: String]? {
-        switch self {
-        default:
-            return NetworkEnv.HTTPHeaderFields.default
-        }
+        return .none
     }
     
     var task: Task {

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -13,6 +13,7 @@ import RxSwift
 final class AuthInterceptor: RequestInterceptor {
     
     private let disposeBag = DisposeBag()
+    private let reissueApiService = ReissueAPIService()
  
     func adapt(_ urlRequest: URLRequest,
                for session: Session,
@@ -44,7 +45,7 @@ final class AuthInterceptor: RequestInterceptor {
         }
         
         // 토큰 재발급 요청
-        ReissueAPIService.shared.reissueAuthentication()
+        reissueApiService.reissueAuthentication()
             .subscribe(onSuccess: { result in
                 Keychain.create(key: Keychain.Keys.accessToken, data: result?.accessToken ?? "")
                 Keychain.create(key: Keychain.Keys.refreshToken, data: result?.refreshToken ?? "")

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -1,0 +1,58 @@
+//
+//  AuthInterceptor.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/08/18.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+final class AuthInterceptor: RequestInterceptor {
+    
+    private let disposeBag = DisposeBag()
+ 
+    func adapt(_ urlRequest: URLRequest,
+               for session: Session,
+               completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        guard let accessToken = Keychain.read(key: Keychain.Keys.accessToken),
+              let refreshToken = Keychain.read(key: Keychain.Keys.refreshToken)
+        else {
+            completion(.success(urlRequest))
+            return
+        }
+        
+        // request header 설정
+        var urlRequest = urlRequest
+        urlRequest.headers.add(.authorization(bearerToken: accessToken))
+        if let urlString = urlRequest.url?.absoluteString, urlString.hasSuffix("/reissue/token") {
+            urlRequest.headers.add(.authorization(bearerToken: refreshToken))
+        }
+        completion(.success(urlRequest))
+    }
+    
+    func retry(_ request: Request,
+               for _: Session,
+               dueTo error: Error,
+               completion: @escaping (RetryResult) -> Void) {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
+        else {
+            completion(.doNotRetryWithError(error))
+            return
+        }
+        
+        // 토큰 재발급 요청
+        ReissueAPIService.shared.reissueAuthentication()
+            .subscribe(onSuccess: { result in
+                Keychain.create(key: Keychain.Keys.accessToken, data: result?.accessToken ?? "")
+                Keychain.create(key: Keychain.Keys.refreshToken, data: result?.refreshToken ?? "")
+                completion(.retry)
+            }, onFailure: { error in
+                // TODO: 토큰 재발급 실패 - 로그인 화면으로 전환
+                completion(.doNotRetryWithError(error))
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -13,7 +13,6 @@ import RxSwift
 final class AuthInterceptor: RequestInterceptor {
     
     private let disposeBag = DisposeBag()
-    private let reissueApiService = ReissueAPIService()
  
     func adapt(_ urlRequest: URLRequest,
                for session: Session,
@@ -45,7 +44,7 @@ final class AuthInterceptor: RequestInterceptor {
         }
         
         // 토큰 재발급 요청
-        reissueApiService.reissueAuthentication()
+        ReissueAPIService.shared.reissueAuthentication()
             .subscribe(onSuccess: { result in
                 Keychain.create(key: Keychain.Keys.accessToken, data: result?.accessToken ?? "")
                 Keychain.create(key: Keychain.Keys.refreshToken, data: result?.refreshToken ?? "")

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -13,11 +13,7 @@ import RxSwift
 final class AuthInterceptor: RequestInterceptor {
     
     private let disposeBag = DisposeBag()
-    private let reissueAuth: Reissueable
-    
-    init(reissueAuth: Reissueable) {
-        self.reissueAuth = reissueAuth
-    }
+    private let reissueApiService = ReissueAPIService()
  
     func adapt(_ urlRequest: URLRequest,
                for session: Session,
@@ -49,7 +45,7 @@ final class AuthInterceptor: RequestInterceptor {
         }
         
         // 토큰 재발급 요청
-        reissueAuth.reissueAuthentication()
+        reissueApiService.reissueAuthentication()
             .subscribe(onSuccess: { result in
                 Keychain.create(key: Keychain.Keys.accessToken, data: result?.accessToken ?? "")
                 Keychain.create(key: Keychain.Keys.refreshToken, data: result?.refreshToken ?? "")

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -13,7 +13,11 @@ import RxSwift
 final class AuthInterceptor: RequestInterceptor {
     
     private let disposeBag = DisposeBag()
-    private let reissueApiService = ReissueAPIService()
+    private let reissueAuth: Reissueable
+    
+    init(reissueAuth: Reissueable) {
+        self.reissueAuth = reissueAuth
+    }
  
     func adapt(_ urlRequest: URLRequest,
                for session: Session,
@@ -45,7 +49,7 @@ final class AuthInterceptor: RequestInterceptor {
         }
         
         // 토큰 재발급 요청
-        reissueApiService.reissueAuthentication()
+        reissueAuth.reissueAuthentication()
             .subscribe(onSuccess: { result in
                 Keychain.create(key: Keychain.Keys.accessToken, data: result?.accessToken ?? "")
                 Keychain.create(key: Keychain.Keys.refreshToken, data: result?.refreshToken ?? "")

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/NetworkEnv.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/NetworkEnv.swift
@@ -11,13 +11,3 @@ enum NetworkEnv {
     // BaseURL
     static let baseURL = "http://fogfogdev-env-1.eba-9u3ghscu.ap-northeast-2.elasticbeanstalk.com"
 }
-
-extension NetworkEnv {
-    
-    enum HTTPHeaderFields {
-        static let `default`: [String: String] = [
-            "Content-Type": "application/json",
-            "Authorization": "Bearer \(Keychain.read(key: Keychain.Keys.accessToken) ?? "")"
-        ]
-    }
-}

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/Networking.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/Networking.swift
@@ -30,11 +30,9 @@ extension Networking {
 final class NetworkProvider<API: FogAPI>: Networking {
 
     private let provider: MoyaProvider<API>
-    private let interceptor: AuthInterceptor
-    private let reissueService = ReissueAPIService()
+    private let interceptor = AuthInterceptor()
     
     init(plugins: [PluginType] = []) {
-        self.interceptor = AuthInterceptor(reissueAuth: reissueService)
         let session = Session(interceptor: interceptor)
         session.sessionConfiguration.timeoutIntervalForRequest = 10
         

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/Networking.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/Networking.swift
@@ -30,14 +30,15 @@ extension Networking {
 final class NetworkProvider<API: FogAPI>: Networking {
 
     private let provider: MoyaProvider<API>
+    private let interceptor = AuthInterceptor()
     
     init(plugins: [PluginType] = []) {
-        let session = MoyaProvider<API>.defaultAlamofireSession()
+        let session = Session(interceptor: interceptor)
         session.sessionConfiguration.timeoutIntervalForRequest = 10
         
         self.provider = MoyaProvider(session: session, plugins: plugins)
     }
-
+    
     func request(
         _ api: API,
         file: StaticString = #file,
@@ -51,16 +52,8 @@ final class NetworkProvider<API: FogAPI>: Networking {
                 onSuccess: { response in
                     print("SUCCESS: \(requestString) (\(response.statusCode))")
                 },
-                onError: { error in
-                    if let error = error as? MoyaError {
-                        switch error {
-                        case .statusCode(let response):
-                            if response.statusCode == 401 {
-                                // Unauthorized - token refresh
-                            }
-                        default: break
-                        }
-                    }
+                onError: { _ in
+                    print("ERROR: \(requestString)")
                 },
                 onSubscribed: {
                     print("REQUEST: \(requestString)")

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/Networking.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/Networking.swift
@@ -30,9 +30,11 @@ extension Networking {
 final class NetworkProvider<API: FogAPI>: Networking {
 
     private let provider: MoyaProvider<API>
-    private let interceptor = AuthInterceptor()
+    private let interceptor: AuthInterceptor
+    private let reissueService = ReissueAPIService()
     
     init(plugins: [PluginType] = []) {
+        self.interceptor = AuthInterceptor(reissueAuth: reissueService)
         let session = Session(interceptor: interceptor)
         session.sessionConfiguration.timeoutIntervalForRequest = 10
         

--- a/FogFog-iOS/FogFog-iOS/OAuth/OAuthProviderType.swift
+++ b/FogFog-iOS/FogFog-iOS/OAuth/OAuthProviderType.swift
@@ -16,7 +16,7 @@ enum OAuthProviderType: String, Hashable, CaseIterable {
     case kakao
     case apple
     
-    var servive: OAuthServiceType {
+    var service: OAuthServiceType {
         switch self {
         case .kakao:
             return KakaoOAuthService()

--- a/FogFog-iOS/FogFog-iOS/Presentation/ExternalMap/ExternalMapModalViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/ExternalMap/ExternalMapModalViewModel.swift
@@ -11,60 +11,60 @@ import RxCocoa
 import RxSwift
 
 final class ExternalMapModalViewModel: ViewModelType {
-  
-  var disposeBag = DisposeBag()
-  
-  struct Input {
-    let kakaoMapButtonDidTap: ControlEvent<Void>
-    let googleMapButtonDidTap: ControlEvent<Void>
-    let naverMapButtonDidTap: ControlEvent<Void>
-    let confirmButtonDidTap: ControlEvent<Void>
-    let closeButtonDidTap: ControlEvent<Void>
-  }
-  
-  struct Output {
-    let selectedMap: PublishRelay<ExternalMapType>
-  }
-  
-  func transform(input: Input) -> Output {
-    let selectedMap = PublishRelay<ExternalMapType>()
-
-    input.kakaoMapButtonDidTap
-      .asSignal()
-      .map { ExternalMapType.kakao }
-      .emit(to: selectedMap)
-      .disposed(by: disposeBag)
-
-    input.googleMapButtonDidTap
-      .asSignal()
-      .map { ExternalMapType.google }
-      .emit(to: selectedMap)
-      .disposed(by: disposeBag)
     
-    input.naverMapButtonDidTap
-      .asSignal()
-      .map { ExternalMapType.naver }
-      .emit(to: selectedMap)
-      .disposed(by: disposeBag)
-
-    input.confirmButtonDidTap
-      .withLatestFrom(selectedMap)
-      .withUnretained(self)
-      .flatMap { owner, mapType in
-        let userId = UserDefaults.userId ?? 13
-        let mapId = mapType.rawValue
-        return owner.setPreferredMap(userId: userId, mapId: mapId)
-      }
-      .subscribe()
-      .disposed(by: disposeBag)
-
-    return Output(selectedMap: selectedMap)
-  }
-  
-  func setPreferredMap(userId: Int, mapId: Int) -> Observable<Void> {
-    return UserAPIService.shared
-      .setPreferredMap(userId: userId, mapId: mapId)
-      .compactMap { _ in () }
-      .asObservable()
-  }
+    var disposeBag = DisposeBag()
+    
+    struct Input {
+        let kakaoMapButtonDidTap: ControlEvent<Void>
+        let googleMapButtonDidTap: ControlEvent<Void>
+        let naverMapButtonDidTap: ControlEvent<Void>
+        let confirmButtonDidTap: ControlEvent<Void>
+        let closeButtonDidTap: ControlEvent<Void>
+    }
+    
+    struct Output {
+        let selectedMap: PublishRelay<ExternalMapType>
+    }
+    
+    func transform(input: Input) -> Output {
+        let selectedMap = PublishRelay<ExternalMapType>()
+        
+        input.kakaoMapButtonDidTap
+            .asSignal()
+            .map { ExternalMapType.kakao }
+            .emit(to: selectedMap)
+            .disposed(by: disposeBag)
+        
+        input.googleMapButtonDidTap
+            .asSignal()
+            .map { ExternalMapType.google }
+            .emit(to: selectedMap)
+            .disposed(by: disposeBag)
+        
+        input.naverMapButtonDidTap
+            .asSignal()
+            .map { ExternalMapType.naver }
+            .emit(to: selectedMap)
+            .disposed(by: disposeBag)
+        
+        input.confirmButtonDidTap
+            .withLatestFrom(selectedMap)
+            .withUnretained(self)
+            .flatMap { owner, mapType in
+                let userId = UserDefaults.userId ?? 13
+                let mapId = mapType.rawValue
+                return owner.setPreferredMap(userId: userId, mapId: mapId)
+            }
+            .subscribe()
+            .disposed(by: disposeBag)
+        
+        return Output(selectedMap: selectedMap)
+    }
+    
+    func setPreferredMap(userId: Int, mapId: Int) -> Observable<Void> {
+        return UserAPIService.shared
+            .setPreferredMap(userId: userId, mapId: mapId)
+            .compactMap { _ in () }
+            .asObservable()
+    }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
@@ -25,7 +25,7 @@ final class DefaultLoginCoordinator: LoginCoordinator {
     func showLoginViewController() {
         let coordinator = DefaultLoginCoordinator(navigationController)
         let viewModel = LoginViewModel(coordinator: coordinator) { oauthProviderType in
-            let oauthService = oauthProviderType.servive
+            let oauthService = oauthProviderType.service
             let authService = AuthAPIService(oauthService: oauthService)
             return authService
         }


### PR DESCRIPTION
## 🔍 What is this PR?
모든 요청에서 401 에러 발생 시 accessToken이 갱신될 수 있도록 토큰 갱신 로직을 구현했습니다.

## 📝 Changes
- `AuthInterceptor`추가
모든 API의 401 에러 부분을 공통적으로 처리할 수 있도록 Alamofire 프레임워크 내 `RequestInterceptor` 프로토콜을 이용했습니다.
    - adapt, retry 함수 구현
        - `adapt`:  request가 전송되기 전에 원하는 추가적인 작업을 수행할 수 있도록 하는 함수 (request header 필드에 토큰 넣어줌)
        **+** adapt 함수 구현으로 따로 request header 설정이 필요없게 되어 해당 부분 코드 삭제해주었습니다. 
        -  `retry`: request가 전송되고 받은 response에 따라 수행할 작업을 지정할 수 있음. (401 에러 처리) 
    
## 📸 Screenshot

## ☑️ Test Checklist
- [x] adapt 실행 테스트
- [x] retry함수에서 error 발생 시 다시 retry 하지 않고 로그인 화면으로 전환 로직 테스트
- [ ] retry함수에서 토큰 갱신 성공 테스트

설정한 로직대로 실행되는지는 테스트 완료한 상태이고, 
토큰 만료 시 리프레시 토큰으로 정상적으로 액세스 토큰 갱신이 되는지는 추후에 테스트가 필요할 것 같습니다!
## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #54
