### PR TITLE
[#67] 로그인 플로우에서 설정 뷰로 화면전환 되지 않는 문제 해결

### DIFF
--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
@@ -23,8 +23,7 @@ final class DefaultLoginCoordinator: LoginCoordinator {
     }
     
     func showLoginViewController() {
-        let coordinator = DefaultLoginCoordinator(navigationController)
-        let viewModel = LoginViewModel(coordinator: coordinator) { oauthProviderType in
+        let viewModel = LoginViewModel(coordinator: self) { oauthProviderType in
             let oauthService = oauthProviderType.service
             let authService = AuthAPIService(oauthService: oauthService)
             return authService

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/MakeNicknameViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/MakeNicknameViewModel.swift
@@ -84,7 +84,7 @@ extension MakeNicknameViewModel {
             .subscribe(onSuccess: { result in
                 // 닉네임 등록 or 수정 성공 시 UserDefaults 값 갱신, 화면 전환
                 UserDefaults.nickname = result?.nickname
-                self.coordinator?.connectMapCoordinator()
+                self.coordinator?.finish()
             }, onFailure: { error in
                 if let networkError = error as? NetworkError {
                     switch networkError {

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -90,7 +90,8 @@ extension MapViewController {
     
     private func bind() {
         let input = MapViewModel.Input(
-            viewDidLoad: Signal<Void>.just(()),
+            viewDidLoad: self.rx.viewDidLoad,
+            viewWillAppear: self.rx.viewWillAppear,
             tapMenuButton: navigationView.rx.menuButtonTapped,
             tapBlurEffectView: tapBlurEffectView.asSignal(),
             tapSettingButton: sideBarView.rx.settingButtonTapped)

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -93,7 +93,7 @@ extension MapViewController {
             viewDidLoad: Signal<Void>.just(()),
             tapMenuButton: navigationView.rx.menuButtonTapped,
             tapBlurEffectView: tapBlurEffectView.asSignal(),
-            tapSettingButton: sideBarView.settingButtonDidTap())
+            tapSettingButton: sideBarView.rx.settingButtonTapped)
         let output = viewModel.transform(input: input)
         
         output.isVisible

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewController.swift
@@ -109,7 +109,7 @@ extension MapViewController {
         
         output.userNickname
             .subscribe(onNext: { result in
-                self.sideBarView.nicknameLabel.text = result
+                self.sideBarView.setNickname(result)
             })
             .disposed(by: disposeBag)
         

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -34,7 +34,7 @@ final class MapViewModel: ViewModelType {
         let viewDidLoad: Signal<Void>
         let tapMenuButton: ControlEvent<Void>
         let tapBlurEffectView: Signal<Void>
-        let tapSettingButton: Signal<Void>
+        let tapSettingButton: ControlEvent<Void>
     }
     
     struct Output {
@@ -80,10 +80,9 @@ final class MapViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.tapSettingButton
-            .withUnretained(self)
-            .emit { owner, _ in
-                owner.coordinator?.connectSettingCoordinator()
-            }
+            .subscribe(onNext: { _ in
+                self.coordinator?.connectSettingCoordinator()
+            })
             .disposed(by: disposeBag)
         
         self.userLocation

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -58,18 +58,18 @@ final class MapViewModel: ViewModelType {
                             currentUserLocation: currentUserLocation.asDriver(onErrorJustReturn: CLLocationCoordinate2D(latitude: 20, longitude: 20)))
         
         input.viewDidLoad
-            .subscribe(onNext: { _ in
-                self.checkAuthorization()
-                self.observeUserLocation()
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.checkAuthorization()
+                owner.observeUserLocation()
                 if UserDefaults.nickname == nil {
-                    self.getUserNicknameAPI(userId: UserDefaults.userId ?? -1)
+                    owner.getUserNicknameAPI(userId: UserDefaults.userId ?? -1)
                 }
             })
             .disposed(by: disposeBag)
         
         input.viewWillAppear
-            .subscribe(onNext: { _ in
-                self.userNickname.onNext(UserDefaults.nickname ?? "")
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.userNickname.onNext(UserDefaults.nickname ?? "")
             })
             .disposed(by: disposeBag)
         
@@ -86,8 +86,8 @@ final class MapViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.tapSettingButton
-            .subscribe(onNext: { _ in
-                self.coordinator?.connectSettingCoordinator()
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.coordinator?.connectSettingCoordinator()
             })
             .disposed(by: disposeBag)
         

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -31,7 +31,8 @@ final class MapViewModel: ViewModelType {
     }
     
     struct Input {
-        let viewDidLoad: Signal<Void>
+        let viewDidLoad: ControlEvent<Void>
+        let viewWillAppear: ControlEvent<Bool>
         let tapMenuButton: ControlEvent<Void>
         let tapBlurEffectView: Signal<Void>
         let tapSettingButton: ControlEvent<Void>
@@ -57,13 +58,18 @@ final class MapViewModel: ViewModelType {
                             currentUserLocation: currentUserLocation.asDriver(onErrorJustReturn: CLLocationCoordinate2D(latitude: 20, longitude: 20)))
         
         input.viewDidLoad
-            .withUnretained(self)
-            .emit(onNext: { owner, _ in
-                owner.checkAuthorization()
-                owner.observeUserLocation()
+            .subscribe(onNext: { _ in
+                self.checkAuthorization()
+                self.observeUserLocation()
                 if UserDefaults.nickname == nil {
-                    owner.getUserNicknameAPI(userId: UserDefaults.userId ?? -1)
+                    self.getUserNicknameAPI(userId: UserDefaults.userId ?? -1)
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        input.viewWillAppear
+            .subscribe(onNext: { _ in
+                self.userNickname.onNext(UserDefaults.nickname ?? "")
             })
             .disposed(by: disposeBag)
         

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/Cell/SettingNicknameTableViewCell.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/Cell/SettingNicknameTableViewCell.swift
@@ -63,9 +63,14 @@ final class SettingNicknameTableViewCell: BaseTableViewCell {
 
 // MARK: - Custom Methods
 extension SettingNicknameTableViewCell {
-
+    
     // 닉네임 수정 버튼 터치 이벤트 방출 메서드
     func editNicknameButtonDidTap() -> Signal<Void> {
         return editNicknameButton.rx.tap.asSignal()
+    }
+    
+    // 닉네임 설정 메서드
+    func setNickname(_ nickname: String) {
+        nicknameLabel.text = nickname
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
@@ -42,6 +42,6 @@ extension DefaultSettingCoordinator: CoordinatorFinishDelegate {
     
     func didFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0.type != childCoordinator.type }
-        childCoordinator.navigationController.popToRootViewController(animated: true)
+        self.navigationController.popViewController(animated: true)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewController/SettingViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewController/SettingViewController.swift
@@ -92,7 +92,9 @@ final class SettingViewController: BaseViewController {
             
             switch indexPath.row {
             case 0:
-                let input = SettingViewModel.Input(tapBackButton: self.navigationView.backButtonDidTap(), tapEditNicknameButton: editNicknameCell.editNicknameButtonDidTap())
+                let input = SettingViewModel.Input(viewWillAppear: self.rx.viewWillAppear,
+                                                   tapBackButton: self.navigationView.backButtonDidTap(),
+                                                   tapEditNicknameButton: editNicknameCell.editNicknameButtonDidTap())
                 let output = self.viewModel.transform(input: input)
                 
                 output.didBackButtonTapped
@@ -101,6 +103,12 @@ final class SettingViewController: BaseViewController {
                 
                 output.didEditNicknameButtonTapped
                     .emit()
+                    .disposed(by: self.disposeBag)
+                
+                output.nickname
+                    .subscribe(onNext: { result in
+                        editNicknameCell.setNickname(result)
+                    })
                     .disposed(by: self.disposeBag)
                 
                 return editNicknameCell

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -41,8 +41,8 @@ final class SettingViewModel: ViewModelType {
                             didEditNicknameButtonTapped: didEditNicknameButtonTapped.asSignal())
         
         input.viewWillAppear
-            .subscribe(onNext: { _ in
-                self.nickname.onNext(UserDefaults.nickname ?? "")
+            .subscribe(with: self, onNext: { owner, _ in
+                owner.nickname.onNext(UserDefaults.nickname ?? "")
             })
             .disposed(by: disposeBag)
         

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -20,20 +20,31 @@ final class SettingViewModel: ViewModelType {
     }
     
     struct Input {
+        let viewWillAppear: ControlEvent<Bool>
         let tapBackButton: Signal<Void>
         let tapEditNicknameButton: Signal<Void>
     }
     
     struct Output {
+        let nickname: BehaviorSubject<String>
         let didBackButtonTapped: Signal<Void>
         let didEditNicknameButtonTapped: Signal<Void>
     }
     
+    let nickname = BehaviorSubject<String>(value: UserDefaults.nickname ?? "")
+    
     func transform(input: Input) -> Output {
         let didBackButtonTapped = PublishRelay<Void>()
         let didEditNicknameButtonTapped = PublishRelay<Void>()
-        let output = Output(didBackButtonTapped: didBackButtonTapped.asSignal(),
+        let output = Output(nickname: nickname,
+                            didBackButtonTapped: didBackButtonTapped.asSignal(),
                             didEditNicknameButtonTapped: didEditNicknameButtonTapped.asSignal())
+        
+        input.viewWillAppear
+            .subscribe(onNext: { _ in
+                self.nickname.onNext(UserDefaults.nickname ?? "")
+            })
+            .disposed(by: disposeBag)
         
         input.tapBackButton
             .withUnretained(self)

--- a/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
@@ -236,7 +236,7 @@ final class SideBarView: BaseView {
     }
 }
 
-// MARK - Custom Methods
+// MARK: - Custom Methods
 extension SideBarView {
     
     /// 닉네임 설정 메서드

--- a/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import RxCocoa
+import RxSwift
 import SnapKit
 import Then
 
@@ -18,7 +19,7 @@ final class SideBarView: BaseView {
     private let logoImageView = UIImageView()
     private let titleLabel = UILabel()
     let nicknameLabel = UILabel()
-    private let settingButton = UIButton()
+    fileprivate let settingButton = UIButton()
     private let mapSettingContainerView = UIView()
     private let mapLogoImageView = UIImageView()
     private let mapSettingTitleLabel = UILabel()
@@ -235,11 +236,9 @@ final class SideBarView: BaseView {
     }
 }
 
-// MARK: - Custom Methods
-extension SideBarView {
-    
-    // 설정 버튼 터치 이벤트 방출하는 메서드
-    func settingButtonDidTap() -> Signal<Void> {
-        return settingButton.rx.tap.asSignal()
+// MARK: - Reactive
+extension Reactive where Base: SideBarView {
+    var settingButtonTapped: ControlEvent<Void> {
+        base.settingButton.rx.tap
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/SideBar/SideBarView.swift
@@ -18,7 +18,7 @@ final class SideBarView: BaseView {
     private let blueView = UIView()
     private let logoImageView = UIImageView()
     private let titleLabel = UILabel()
-    let nicknameLabel = UILabel()
+    private let nicknameLabel = UILabel()
     fileprivate let settingButton = UIButton()
     private let mapSettingContainerView = UIView()
     private let mapLogoImageView = UIImageView()
@@ -233,6 +233,15 @@ final class SideBarView: BaseView {
             $0.height.equalTo(12)
             $0.width.equalTo(45)
         }
+    }
+}
+
+// MARK - Custom Methods
+extension SideBarView {
+    
+    /// 닉네임 설정 메서드
+    func setNickname(_ nickname: String) {
+        nicknameLabel.text = nickname
     }
 }
 

--- a/FogFog-iOS/FogFog-iOS/Utils/Extension/Reactive + Extension.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Extension/Reactive + Extension.swift
@@ -1,0 +1,24 @@
+//
+//  Reactive + Extension.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/09/08.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+extension Reactive where Base: UIViewController {
+    
+    var viewDidLoad: ControlEvent<Void> {
+        let source = self.methodInvoked(#selector(Base.viewDidLoad)).map { _ in }
+        return ControlEvent(events: source)
+    }
+    
+    var viewWillAppear: ControlEvent<Bool> {
+        let source = self.methodInvoked(#selector(Base.viewWillAppear)).map { $0.first as? Bool ?? false }
+        return ControlEvent(events: source)
+    }
+}


### PR DESCRIPTION
## 🔍 What is this PR?
로그인 플로우에서 설정 뷰로 화면전환 되지 않는 문제를 해결했습니다. 
(코디네이터 설정 코드 일부 수정)

## 📝 Changes
- `coordinator.finish()` 함수를 이용해 플로우에 따라 화면 전환이 다르게 이루어질 수 있도록 코드를 수정했습니다.
    - 최초 로그인 시 닉네임 설정 완료 -> `showMapFlow()` 메인 화면으로 이동 
    - 자동 로그인 시 (최초 진입이 mapViewController) 닉네임 수정 완료 -> 뒤로가기 화면전환
- 닉네임 수정 후 UI 업데이트가 바로 반영될 수 있도록 코드를 추가했습니다.
- 자잘한 코드 수정이 있습니다. (이벤트 처리에 Reactive extension 활용 및 프로퍼티 접근 제어 수정)

## 📸 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->


## ☑️ Test Checklist
- [x] 케이스 별 화면 전환 테스트 완료

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #67 
