### PR TITLE
[#71] 토큰 만료 시 로그인 화면으로 전환

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1DDE6DAB87E9F15EAEAD8A1B /* Pods_FogFog_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44BDDCB91FAFFFC51A0C1A4C /* Pods_FogFog_iOS.framework */; };
 		35919B344F294722AA448E4E /* Pods_FogFog_iOS_FogFog_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D67B489E657987D4A7AD92C7 /* Pods_FogFog_iOS_FogFog_iOSUITests.framework */; };
 		56E6DAD19F1058E2F6B779B7 /* Pods_FogFog_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848DD0928406FC10714344E4 /* Pods_FogFog_iOSTests.framework */; };
+		77148CCA2AC69DB8008E24B2 /* NotificationCenterKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77148CC92AC69DB8008E24B2 /* NotificationCenterKey.swift */; };
 		772577D929349212008273A7 /* RxKeyboard in Frameworks */ = {isa = PBXBuildFile; productRef = 772577D829349212008273A7 /* RxKeyboard */; };
 		772577DC2934924E008273A7 /* RxGesture in Frameworks */ = {isa = PBXBuildFile; productRef = 772577DB2934924E008273A7 /* RxGesture */; };
 		775AC1972A735FE800A2A47E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775AC1962A735FE800A2A47E /* Keychain.swift */; };
@@ -161,6 +162,7 @@
 		44BDDCB91FAFFFC51A0C1A4C /* Pods_FogFog_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FogFog_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		47D49EE273F775CA2202B593 /* Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig"; path = "Target Support Files/Pods-FogFog-iOS-FogFog-iOSUITests/Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		568E5A05A08D8D049D3D8E62 /* Pods-FogFog-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOSTests/Pods-FogFog-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		77148CC92AC69DB8008E24B2 /* NotificationCenterKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterKey.swift; sourceTree = "<group>"; };
 		775AC1962A735FE800A2A47E /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		775AC1982A7369C800A2A47E /* Keychain + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Keychain + Extension.swift"; sourceTree = "<group>"; };
 		775DB3742A8F40E800214C8F /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
@@ -926,6 +928,7 @@
 			children = (
 				ECA425DD29253292004DFDAF /* CoordinatorCase.swift */,
 				BDDAA3902A249D090055859E /* Config.swift */,
+				77148CC92AC69DB8008E24B2 /* NotificationCenterKey.swift */,
 			);
 			path = Contstant;
 			sourceTree = "<group>";
@@ -1296,6 +1299,7 @@
 				775DB3752A8F40E800214C8F /* AuthInterceptor.swift in Sources */,
 				77A99D6C2971B0220037FCAD /* DefaultSettingCoordinator.swift in Sources */,
 				BD4572142A8A404D009E9B3C /* EmptyData.swift in Sources */,
+				77148CCA2AC69DB8008E24B2 /* NotificationCenterKey.swift in Sources */,
 				BD4D62AF2A1A100B00532778 /* KakaoOAuthService.swift in Sources */,
 				77E70F4A2930D0FA00F55CD7 /* MakeNicknameViewModel.swift in Sources */,
 				77650210295462D7002BF7AD /* UIViewController + Extension.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -31,7 +31,6 @@ final class ReissueAPIService: Networking {
     func reissueAuthentication() -> Single<SignInResponseDTO?> {
         return provider
             .request(.reissueToken)
-            .retry(2)
             .map(SignInResponseDTO.self)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/APIServices/ReissueAPIService.swift
@@ -31,6 +31,7 @@ final class ReissueAPIService: Networking {
     func reissueAuthentication() -> Single<SignInResponseDTO?> {
         return provider
             .request(.reissueToken)
+            .retry(2)
             .map(SignInResponseDTO.self)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -44,7 +44,7 @@ final class AuthInterceptor: RequestInterceptor {
         }
         
         if let urlString = response.url?.absoluteString, urlString.hasSuffix("/reissue/token") {
-            completion(.doNotRetryWithError(error))
+            completion(.doNotRetry)
             return
         }
         
@@ -55,7 +55,8 @@ final class AuthInterceptor: RequestInterceptor {
                 Keychain.create(key: Keychain.Keys.refreshToken, data: result?.refreshToken ?? "")
                 completion(.retry)
             }, onFailure: { error in
-                // TODO: 토큰 재발급 실패 - 로그인 화면으로 전환
+                // refreshToken 만료 시 로그인 화면으로 전환
+                NotificationCenter.default.post(name: NotificationCenterKey.refreshTokenHasExpired, object: nil)
                 completion(.doNotRetryWithError(error))
             })
             .disposed(by: disposeBag)

--- a/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
+++ b/FogFog-iOS/FogFog-iOS/Networking/Foundation/AuthInterceptor.swift
@@ -43,7 +43,12 @@ final class AuthInterceptor: RequestInterceptor {
             return
         }
         
-        // 토큰 재발급 요청
+        if let urlString = response.url?.absoluteString, urlString.hasSuffix("/reissue/token") {
+            completion(.doNotRetryWithError(error))
+            return
+        }
+        
+        // 토큰 재발급 요청 (401일 떄)
         ReissueAPIService.shared.reissueAuthentication()
             .subscribe(onSuccess: { result in
                 Keychain.create(key: Keychain.Keys.accessToken, data: result?.accessToken ?? "")

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/DefaultAppCoordinator.swift
@@ -20,6 +20,12 @@ final class DefaultAppCoordinator: AppCoordinator {
         // BaseViewController에서 ViewWillAppear에 해당하는 부분인데
         // BaseViewController에서 코드를 지울지, 아래의 코드를 지울지 논의 필요
         navigationController.setNavigationBarHidden(true, animated: true)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(popToRoot),
+            name: NotificationCenterKey.refreshTokenHasExpired,
+            object: nil
+        )
     }
     
     func start() {
@@ -44,6 +50,11 @@ final class DefaultAppCoordinator: AppCoordinator {
         mapCoordinator.finishDelegate = self
         mapCoordinator.start()
         childCoordinators.append(mapCoordinator)
+    }
+    
+    @objc
+    func popToRoot(_ notification: Notification) {
+        showLoginFlow()
     }
 }
 

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
@@ -39,12 +39,6 @@ final class DefaultLoginCoordinator: LoginCoordinator {
         makeNicknameController.setNaviTitle(.create)
     }
     
-    func connectMapCoordinator() {
-        let mapCoordinator = DefaultMapCoordinator(self.navigationController)
-        mapCoordinator.start()
-        self.childCoordinators.append(mapCoordinator)
-    }
-    
     func finish() {
         finishDelegate?
             .didFinish(childCoordinator: self)

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/DefaultLoginCoordinator.swift
@@ -32,11 +32,11 @@ final class DefaultLoginCoordinator: LoginCoordinator {
         navigationController.pushViewController(loginViewController, animated: false)
     }
     
-    func showMakeNicknameViewController(to type: MakeNicknameViewType) {
+    func showMakeNicknameViewController() {
         let makeNicknameViewModel = MakeNicknameViewModel(coordinator: self)
         let makeNicknameController = MakeNicknameViewController(viewModel: makeNicknameViewModel)
         navigationController.pushViewController(makeNicknameController, animated: true)
-        makeNicknameController.setNaviTitle(type)
+        makeNicknameController.setNaviTitle(.create)
     }
     
     func connectMapCoordinator() {

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/Protocol/LoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/Protocol/LoginCoordinator.swift
@@ -9,6 +9,6 @@ import Foundation
 
 protocol LoginCoordinator: Coordinator {
     func showLoginViewController()
-    func showMakeNicknameViewController(to type: MakeNicknameViewType)
+    func showMakeNicknameViewController()
     func connectMapCoordinator()
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/Protocol/LoginCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/Coordinator/Protocol/LoginCoordinator.swift
@@ -10,5 +10,4 @@ import Foundation
 protocol LoginCoordinator: Coordinator {
     func showLoginViewController()
     func showMakeNicknameViewController()
-    func connectMapCoordinator()
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -44,8 +44,11 @@ final class LoginViewModel: ViewModelType {
         input.kakaoButtonDidTap
             .flatMap(loginWithKakao)
             .subscribe { _ in
-                result.onNext("success!")
-                self.coordinator.showMakeNicknameViewController(to: .create)
+                if UserDefaults.nickname == nil {
+                    self.coordinator.showMakeNicknameViewController()
+                } else {
+                    self.coordinator.finish()
+                }
             } onError: { error in
                 result.onNext("error: \(error.localizedDescription)")
             }
@@ -54,8 +57,11 @@ final class LoginViewModel: ViewModelType {
         input.appleButtonDidTap
             .flatMap(loginWithApple)
             .subscribe { _ in
-                result.onNext("success!")
-                self.coordinator.showMakeNicknameViewController(to: .create)
+                if UserDefaults.nickname == nil {
+                    self.coordinator.showMakeNicknameViewController()
+                } else {
+                    self.coordinator.finish()
+                }
             } onError: { error in
                 result.onNext("error: \(error.localizedDescription)")
             }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/MakeNicknameViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Login/ViewModel/MakeNicknameViewModel.swift
@@ -15,9 +15,9 @@ final class MakeNicknameViewModel: ViewModelType {
     
     var disposeBag = DisposeBag()
     
-    private weak var coordinator: LoginCoordinator?
+    private weak var coordinator: Coordinator?
     
-    init(coordinator: LoginCoordinator?) {
+    init(coordinator: Coordinator?) {
         self.coordinator = coordinator
     }
     

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/DefaultMapCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/DefaultMapCoordinator.swift
@@ -29,7 +29,7 @@ final class DefaultMapCoordinator: MapCoordinator {
         navigationController.viewControllers = [mapViewController]
     }
     
-    func connectSettingCoordinator() {
+    func showSettingFlow() {
         let settingCoordinator = DefaultSettingCoordinator(self.navigationController)
         settingCoordinator.finishDelegate = self
         self.childCoordinators.append(settingCoordinator)

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/Protocol/MapCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/Coordinator/Protocol/MapCoordinator.swift
@@ -10,5 +10,5 @@ import Foundation
 protocol MapCoordinator: Coordinator {
     
     func showMapViewController()
-    func connectSettingCoordinator()
+    func showSettingFlow()
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Map/MapViewModel.swift
@@ -87,7 +87,7 @@ final class MapViewModel: ViewModelType {
         
         input.tapSettingButton
             .subscribe(with: self, onNext: { owner, _ in
-                owner.coordinator?.connectSettingCoordinator()
+                owner.coordinator?.showSettingFlow()
             })
             .disposed(by: disposeBag)
         

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
@@ -18,6 +18,15 @@ final class DefaultSettingCoordinator: SettingCoordinator {
         self.navigationController = navigationController
     }
     
+    func start() {
+        showSettingViewController()
+    }
+    
+    func finish() {
+        finishDelegate?
+            .didFinish(childCoordinator: self)
+    }
+    
     func showSettingViewController() {
         let settingViewModel = SettingViewModel(coordinator: self)
         let settingViewController = SettingViewController(viewModel: settingViewModel)
@@ -25,15 +34,11 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     }
     
     // 닉네임 수정 뷰로 이동
-    func connectLoginCoordinator() {
-        let loginCoordinator = DefaultLoginCoordinator(self.navigationController)
-        loginCoordinator.finishDelegate = self
-        self.childCoordinators.append(loginCoordinator)
-        loginCoordinator.showMakeNicknameViewController(to: .edit)
-    }
-    
-    func start() {
-        showSettingViewController()
+    func showEditNicknameViewController() {
+        let editNicknameViewModel = MakeNicknameViewModel(coordinator: self)
+        let editNicknameViewController = MakeNicknameViewController(viewModel: editNicknameViewModel)
+        navigationController.pushViewController(editNicknameViewController, animated: true)
+        editNicknameViewController.setNaviTitle(.edit)
     }
 }
 
@@ -42,6 +47,6 @@ extension DefaultSettingCoordinator: CoordinatorFinishDelegate {
     
     func didFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0.type != childCoordinator.type }
-        self.navigationController.popViewController(animated: true)
+        childCoordinator.navigationController.popToRootViewController(animated: true)
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/Protocol/SettingCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/Protocol/SettingCoordinator.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol SettingCoordinator: Coordinator {
     func showSettingViewController()
-    func connectLoginCoordinator()
+    func showEditNicknameViewController()
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -56,7 +56,7 @@ final class SettingViewModel: ViewModelType {
         input.tapEditNicknameButton
             .withUnretained(self)
             .emit { owner, _ in
-                owner.coordinator?.connectLoginCoordinator()
+                owner.coordinator?.showEditNicknameViewController()
             }
             .disposed(by: disposeBag)
         

--- a/FogFog-iOS/FogFog-iOS/Utils/Contstant/NotificationCenterKey.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Contstant/NotificationCenterKey.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationCenterKey.swift
+//  FogFog-iOS
+//
+//  Created by EUNJU on 2023/09/29.
+//
+
+import Foundation
+
+enum NotificationCenterKey {
+    static let refreshTokenHasExpired = Notification.Name("refreshTokenHasExpired")
+}


### PR DESCRIPTION
## 🔍 What is this PR?
리프레시 토큰이 만료될 경우 토큰을 새로 발급받을 수 있도록 로그인 화면으로 전환될 수 있도록 구현했습니다.

## 📝 Changes
- `NotificationCenter`를 이용해 `refreshToken` 만료 시 `DefaultAppCoordinator`의 `showLoginFlow()`를 호출하는 방식으로 화면 전환 처리를 해주었습니다. (`Coordinator` 프로토콜 내에서 `popToRoot()` 함수를 생성해 공통 화면 전환을 처리해보려 했지만 새로운 코디네이터 인스턴스를 생성하는 방식이기 때문에 로그인 성공 이후 화면전환이 제대로 이루어지지 않아서 노티를 사용했습니다,,)
- `SettingCoordinator` 관련 일부 코드를 수정했습니다.
    - 설정 뷰 플로우에 닉네임 수정 화면이 포함되는데, 기존 코드에서 코디네이터까지 `LoginCoordinator`로 전환해주는 방식으로 구현되어있어(분명 제가 짰던 코드였는데요;;) 뷰만 재사용하는 방식으로 수정했습니다.
- 로그인 화면으로 전환 시 transition 이 어색한 것 같은데(뚝 끊기는 느낌), 애니메이션 적용 or 중간에 팝업을 넣을지? 요런거 논의해서 수정하면 좋을 것 같습니다!

**+** 다들 연휴 잘보내 ~~~

## 📸 Screenshot
- 토큰 만료된 상태로 닉네임 수정 요청 -> 재로그인 -> 요청 정상 처리

https://github.com/TeamFogFog/FogFog-iOS/assets/63277563/fc7384af-c714-4d48-b8fd-a9ed777a8681

## ☑️ Test Checklist
- [x] 토큰 만료 케이스 테스트 완료
- [x] 화면전환 플로우 확인

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #71 
