### PR TITLE
[#80] 네비게이션 컨트롤러 Pop Gesture 추가

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		BDC20F9D293B44B600B9A2E7 /* FogToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC20F9C293B44B600B9A2E7 /* FogToast.swift */; };
 		BDC50ED2292A07EB002378C6 /* SmokingAreaDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */; };
 		BDC50ED6292A09BD002378C6 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC50ED5292A09BD002378C6 /* BaseView.swift */; };
+		BDC795D82AE5371D0068109F /* BaseNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC795D72AE5371D0068109F /* BaseNavigationController.swift */; };
 		BDDAA3912A249D090055859E /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3902A249D090055859E /* Config.swift */; };
 		BDDAA3932A24B9D00055859E /* OAuthServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3922A24B9D00055859E /* OAuthServiceType.swift */; };
 		BDDAA3952A24BA130055859E /* OAuthAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */; };
@@ -238,6 +239,7 @@
 		BDC20F9C293B44B600B9A2E7 /* FogToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FogToast.swift; sourceTree = "<group>"; };
 		BDC50ED1292A07EB002378C6 /* SmokingAreaDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokingAreaDetailViewModel.swift; sourceTree = "<group>"; };
 		BDC50ED5292A09BD002378C6 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		BDC795D72AE5371D0068109F /* BaseNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavigationController.swift; sourceTree = "<group>"; };
 		BDDAA3902A249D090055859E /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		BDDAA3922A24B9D00055859E /* OAuthServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthServiceType.swift; sourceTree = "<group>"; };
 		BDDAA3942A24BA130055859E /* OAuthAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthAuthentication.swift; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 				ECA4257D292254C6004DFDAF /* BaseViewController.swift */,
 				BDC50ED5292A09BD002378C6 /* BaseView.swift */,
 				77650211295463B8002BF7AD /* BaseTableViewCell.swift */,
+				BDC795D72AE5371D0068109F /* BaseNavigationController.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1359,6 +1362,7 @@
 				77A99D6A2971AFDC0037FCAD /* SettingCoordinator.swift in Sources */,
 				BDDAA3932A24B9D00055859E /* OAuthServiceType.swift in Sources */,
 				ECA4259729229B15004DFDAF /* FogFont.swift in Sources */,
+				BDC795D82AE5371D0068109F /* BaseNavigationController.swift in Sources */,
 				BDC50ED2292A07EB002378C6 /* SmokingAreaDetailViewModel.swift in Sources */,
 				77CB027F29DEAE57006817E5 /* RxMoya + Extension.swift in Sources */,
 				BDB6E1F52A30383700AE6228 /* NetworkMonitor.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/App/SceneDelegate.swift
+++ b/FogFog-iOS/FogFog-iOS/App/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        let navigationController = UINavigationController()
+        let navigationController = BaseNavigationController()
         self.appCoordinator = DefaultAppCoordinator(navigationController)
         self.appCoordinator?.start()
         self.window = UIWindow(windowScene: windowScene)

--- a/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Protocol/Coordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Common/Coordinator/Protocol/Coordinator.swift
@@ -8,38 +8,36 @@
 import UIKit
 
 protocol Coordinator: AnyObject {
-
     var finishDelegate: CoordinatorFinishDelegate? { get set }
     var navigationController: UINavigationController { get set }
     var childCoordinators: [Coordinator] { get set }
     var type: CoordinatorCase { get }
+    
     func start()
     func finish()
-
+    
     init(_ navigationController: UINavigationController)
 }
 
 extension Coordinator {
-
+    
     func finish() {
-        
         childCoordinators.removeAll()
-        finishDelegate?
-            .didFinish(childCoordinator: self)
+        finishDelegate?.didFinish(childCoordinator: self)
     }
-
+    
     func changeAnimation() {
-        
         let scenes = UIApplication.shared.connectedScenes
         let windowScene = scenes.first as? UIWindowScene
         let window = windowScene?.windows.first
         
         if let window = window {
-            UIView.transition(with: window,
-                              duration: 0.5,
-                              options: .transitionCrossDissolve,
-                              animations: nil)
+            UIView.transition(
+                with: window,
+                duration: 0.5,
+                options: .transitionCrossDissolve,
+                animations: nil
+            )
         }
     }
 }
-

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DefaultSettingCoordinator: SettingCoordinator {
+final class DefaultSettingCoordinator: NSObject, SettingCoordinator {
     
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
@@ -16,6 +16,8 @@ final class DefaultSettingCoordinator: SettingCoordinator {
     
     init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
+        super.init()
+        navigationController.interactivePopGestureRecognizer?.delegate = self
     }
     
     func start() {
@@ -48,5 +50,13 @@ extension DefaultSettingCoordinator: CoordinatorFinishDelegate {
     func didFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0.type != childCoordinator.type }
         childCoordinator.navigationController.popToRootViewController(animated: true)
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+extension DefaultSettingCoordinator: UIGestureRecognizerDelegate {
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
+++ b/FogFog-iOS/FogFog-iOS/Presentation/Setting/Coordinator/DefaultSettingCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DefaultSettingCoordinator: NSObject, SettingCoordinator {
+final class DefaultSettingCoordinator: SettingCoordinator {
     
     weak var finishDelegate: CoordinatorFinishDelegate?
     var navigationController: UINavigationController
@@ -16,8 +16,6 @@ final class DefaultSettingCoordinator: NSObject, SettingCoordinator {
     
     init(_ navigationController: UINavigationController) {
         self.navigationController = navigationController
-        super.init()
-        navigationController.interactivePopGestureRecognizer?.delegate = self
     }
     
     func start() {
@@ -50,13 +48,5 @@ extension DefaultSettingCoordinator: CoordinatorFinishDelegate {
     func didFinish(childCoordinator: Coordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0.type != childCoordinator.type }
         childCoordinator.navigationController.popToRootViewController(animated: true)
-    }
-}
-
-// MARK: - UIGestureRecognizerDelegate
-extension DefaultSettingCoordinator: UIGestureRecognizerDelegate {
-
-    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return true
     }
 }

--- a/FogFog-iOS/FogFog-iOS/Utils/Base/BaseNavigationController.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Base/BaseNavigationController.swift
@@ -11,12 +11,10 @@ class BaseNavigationController: UINavigationController {
     
     private(set) var isTransitioning: Bool = false
     
-    /// Pop Gesture 막아야 하는 뷰 컨트롤러의 타입 배열
-    private var disabledPopViewControllers: [AnyClass] = []
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.navigationBar.isHidden = true
         self.interactivePopGestureRecognizer?.delegate = self
         self.delegate = self
     }
@@ -36,17 +34,13 @@ extension BaseNavigationController: UIGestureRecognizerDelegate {
         guard gestureRecognizer == interactivePopGestureRecognizer else {
             return true
         }
-    
-        return viewControllers.count > 1 && isTransitioning == false && isPopGestureEnabled()
-    }
-    
-    private func isPopGestureEnabled() -> Bool {
-        guard let topViewController else { return false }
         
-        for viewController in disabledPopViewControllers where topViewController.isKind(of: viewController.self) {
+        // 특정 뷰 컨트롤러에 대해서 Popped 되는 것을 막고 싶다면, preventInteractivePopGesture 오버라이딩해서 false로 수정
+        if let viewController = visibleViewController as? BaseViewController, viewController.preventInteractivePopGesture() {
             return false
         }
-        return true
+        
+        return viewControllers.count > 1 && isTransitioning == false
     }
 }
 

--- a/FogFog-iOS/FogFog-iOS/Utils/Base/BaseNavigationController.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Base/BaseNavigationController.swift
@@ -1,0 +1,60 @@
+//
+//  BaseNavigationController.swift
+//  FogFog-iOS
+//
+//  Created by taekki on 2023/10/22.
+//
+
+import UIKit
+
+class BaseNavigationController: UINavigationController {
+    
+    private(set) var isTransitioning: Bool = false
+    
+    /// Pop Gesture 막아야 하는 뷰 컨트롤러의 타입 배열
+    private var disabledPopViewControllers: [AnyClass] = []
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.interactivePopGestureRecognizer?.delegate = self
+        self.delegate = self
+    }
+    
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        isTransitioning = true
+        
+        super.pushViewController(viewController, animated: animated)
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension BaseNavigationController: UIGestureRecognizerDelegate {
+    
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer == interactivePopGestureRecognizer else {
+            return true
+        }
+    
+        return viewControllers.count > 1 && isTransitioning == false && isPopGestureEnabled()
+    }
+    
+    private func isPopGestureEnabled() -> Bool {
+        guard let topViewController else { return false }
+        
+        for viewController in disabledPopViewControllers where topViewController.isKind(of: viewController.self) {
+            return false
+        }
+        return true
+    }
+}
+
+// MARK: - UINavigationControllerDelegate
+
+extension BaseNavigationController: UINavigationControllerDelegate {
+    
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        isTransitioning = false
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/Utils/Base/BaseViewController.swift
+++ b/FogFog-iOS/FogFog-iOS/Utils/Base/BaseViewController.swift
@@ -9,7 +9,15 @@ import UIKit
 
 import RxSwift
 
-class BaseViewController: UIViewController {
+protocol InteractivePopGesture: AnyObject {
+    /// Pop Gesture를 막을지 결정하는 함수, default: false
+    ///
+    /// 특정 뷰 컨트롤러만 제스처를 막고 싶다면 BaseViewController를 상속 받은 뷰 컨트롤러에서
+    /// 다음 함수를 오버라이드 한 뒤, true로 리턴해주도록 하면 된다.
+    func preventInteractivePopGesture() -> Bool
+}
+
+class BaseViewController: UIViewController, InteractivePopGesture {
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nil, bundle: nil)
@@ -34,11 +42,14 @@ class BaseViewController: UIViewController {
         navigationController?.setNavigationBarHidden(true, animated: true)
     }
     
+    func preventInteractivePopGesture() -> Bool {
+        return false
+    }
+    
     // MARK: UI
     
     /// Attributes (속성) 설정 메서드
     func setStyle() {
-        
         view.backgroundColor = .white
     }
     


### PR DESCRIPTION
## 🔍 What is this PR?
Setting 쪽 흐름으로 넘어가는 부분에 네비게이션 플로우가 있는데 그곳에서 제스처로 뒤로 가기가 가능하게 만들었습니다.

### 배경
뒤로 가기 버튼을 누르는 것도 하나의 에너지 소모라고 느껴서 제스처로 뒤로 가기를 할 수 있도록 구현했습니다. 앱 사용성 측면에서도 충분히 고려해볼만한 지점이라고 생각하고, 많은 서비스에서도 해당 방식을 많이 사용하고 있더라구요! 의견 부탁드리고 우리 앱에 적절치 않다고 판단되면 PR을 다시 고려하겠습니다!

### Reference
- [uigesturerecognizerdelegate](https://developer.apple.com/documentation/uikit/uigesturerecognizerdelegate/1624213-gesturerecognizershouldbegin?language=objc)

e.g. 카카오톡 채팅방, 네이버 웹툰, 토스 잔액 조회 등

## 📝 Changes
- DefaultSettingCoordinator.swift

1. UIGestureRecognizerDelegate 프로토콜을 ViewController가 채택하는 것도 고려해봤는데, 네비게이션 흐름을 Coordinator가 담당하고 있기 때문에 Coordinator 클래스가 채택하고 구현하는 것이 맞다고 생각했습니다.
2. 상황에 따른 분기처리는 지금 당장 필요하지 않아서 기본 구현만 했습니다.

## 📸 Screenshot

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|-|[Video](https://github-production-user-asset-6210df.s3.amazonaws.com/61109660/277102385-11247779-d304-4cd7-9bbd-ffdba4d33989.MP4)|


## ☑️ Test Checklist
- Setting 쪽 흐름에서 제스처로 뒤로 가기가 정상 작동하는지 확인
- 제스처로 인해 사이드 이펙트가 발생하는 부분이 있는지 확인

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #80 
