### PR TITLE
[#84] Concurrency를 사용하여 앱에서 사용하는 네트워크 공통 로직 구현

### DIFF
--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -10,6 +10,13 @@
 		1DDE6DAB87E9F15EAEAD8A1B /* Pods_FogFog_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44BDDCB91FAFFFC51A0C1A4C /* Pods_FogFog_iOS.framework */; };
 		35919B344F294722AA448E4E /* Pods_FogFog_iOS_FogFog_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D67B489E657987D4A7AD92C7 /* Pods_FogFog_iOS_FogFog_iOSUITests.framework */; };
 		56E6DAD19F1058E2F6B779B7 /* Pods_FogFog_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848DD0928406FC10714344E4 /* Pods_FogFog_iOSTests.framework */; };
+		6DCD47AD2D2E0E2E009FD6DF /* ModernHttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47AC2D2E0E18009FD6DF /* ModernHttpMethod.swift */; };
+		6DCD47AF2D2E0E5F009FD6DF /* ModernNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47AE2D2E0E59009FD6DF /* ModernNetworkError.swift */; };
+		6DCD47B72D2E1432009FD6DF /* ModernEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47B62D2E142E009FD6DF /* ModernEndpoint.swift */; };
+		6DCD47B92D2E153C009FD6DF /* ModernURLRequestBuildable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47B82D2E152C009FD6DF /* ModernURLRequestBuildable.swift */; };
+		6DCD47C22D2E42D8009FD6DF /* ModernNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47C12D2E42CB009FD6DF /* ModernNetworkSession.swift */; };
+		6DCD47C42D2E4340009FD6DF /* JSONResponseDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47C32D2E432F009FD6DF /* JSONResponseDecoder.swift */; };
+		6DCD47C62D2E4366009FD6DF /* ModernNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47C52D2E435E009FD6DF /* ModernNetworkService.swift */; };
 		77148CCA2AC69DB8008E24B2 /* NotificationCenterKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77148CC92AC69DB8008E24B2 /* NotificationCenterKey.swift */; };
 		77148CDB2ADEB67E008E24B2 /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77148CDA2ADEB67E008E24B2 /* UserDefaultsKey.swift */; };
 		77148CDF2AE50008008E24B2 /* UserDefaults + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77148CDE2AE50008008E24B2 /* UserDefaults + Extension.swift */; };
@@ -170,6 +177,13 @@
 		44BDDCB91FAFFFC51A0C1A4C /* Pods_FogFog_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FogFog_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		47D49EE273F775CA2202B593 /* Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig"; path = "Target Support Files/Pods-FogFog-iOS-FogFog-iOSUITests/Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		568E5A05A08D8D049D3D8E62 /* Pods-FogFog-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOSTests/Pods-FogFog-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		6DCD47AC2D2E0E18009FD6DF /* ModernHttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernHttpMethod.swift; sourceTree = "<group>"; };
+		6DCD47AE2D2E0E59009FD6DF /* ModernNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernNetworkError.swift; sourceTree = "<group>"; };
+		6DCD47B62D2E142E009FD6DF /* ModernEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernEndpoint.swift; sourceTree = "<group>"; };
+		6DCD47B82D2E152C009FD6DF /* ModernURLRequestBuildable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernURLRequestBuildable.swift; sourceTree = "<group>"; };
+		6DCD47C12D2E42CB009FD6DF /* ModernNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernNetworkSession.swift; sourceTree = "<group>"; };
+		6DCD47C32D2E432F009FD6DF /* JSONResponseDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONResponseDecoder.swift; sourceTree = "<group>"; };
+		6DCD47C52D2E435E009FD6DF /* ModernNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernNetworkService.swift; sourceTree = "<group>"; };
 		77148CC92AC69DB8008E24B2 /* NotificationCenterKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterKey.swift; sourceTree = "<group>"; };
 		77148CDA2ADEB67E008E24B2 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		77148CDE2AE50008008E24B2 /* UserDefaults + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults + Extension.swift"; sourceTree = "<group>"; };
@@ -369,6 +383,20 @@
 				568E5A05A08D8D049D3D8E62 /* Pods-FogFog-iOSTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		6DCD47372D2D0B9E009FD6DF /* ModernNetwork */ = {
+			isa = PBXGroup;
+			children = (
+				6DCD47AC2D2E0E18009FD6DF /* ModernHttpMethod.swift */,
+				6DCD47AE2D2E0E59009FD6DF /* ModernNetworkError.swift */,
+				6DCD47B62D2E142E009FD6DF /* ModernEndpoint.swift */,
+				6DCD47B82D2E152C009FD6DF /* ModernURLRequestBuildable.swift */,
+				6DCD47C12D2E42CB009FD6DF /* ModernNetworkSession.swift */,
+				6DCD47C32D2E432F009FD6DF /* JSONResponseDecoder.swift */,
+				6DCD47C52D2E435E009FD6DF /* ModernNetworkService.swift */,
+			);
+			path = ModernNetwork;
 			sourceTree = "<group>";
 		};
 		775AC1952A735FCC00A2A47E /* Class */ = {
@@ -700,6 +728,7 @@
 		ECA4252B29224DB8004DFDAF /* FogFog-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				6DCD47372D2D0B9E009FD6DF /* ModernNetwork */,
 				BD9AA41529929A7A00D4E7CE /* FogFog-iOS.entitlements */,
 				ECA4255D292251D8004DFDAF /* App */,
 				BD9AA41629929AB200D4E7CE /* Manager */,
@@ -1337,6 +1366,7 @@
 				BD4D62AF2A1A100B00532778 /* KakaoOAuthService.swift in Sources */,
 				77E70F4A2930D0FA00F55CD7 /* MakeNicknameViewModel.swift in Sources */,
 				77650210295462D7002BF7AD /* UIViewController + Extension.swift in Sources */,
+				6DCD47B72D2E1432009FD6DF /* ModernEndpoint.swift in Sources */,
 				BDDAA3952A24BA130055859E /* OAuthAuthentication.swift in Sources */,
 				7765020E29546239002BF7AD /* SettingListTableViewCell.swift in Sources */,
 				BDB6E1FA2A30546D00AE6228 /* Published+Rx.swift in Sources */,
@@ -1352,9 +1382,11 @@
 				BD834A622A8A073300A6DCBD /* ExternalMapModalViewModel.swift in Sources */,
 				BDF434672AB1887C00FFAA45 /* MapAPIService.swift in Sources */,
 				ECA425E629262A42004DFDAF /* DefaultLoginCoordinator.swift in Sources */,
+				6DCD47C22D2E42D8009FD6DF /* ModernNetworkSession.swift in Sources */,
 				BD4EA69E2AB19A73004CE0BB /* QuitAPIService.swift in Sources */,
 				ECA425DC29253259004DFDAF /* CoordinatorFinishDelegate.swift in Sources */,
 				ECA4252D29224DB8004DFDAF /* AppDelegate.swift in Sources */,
+				6DCD47C62D2E4366009FD6DF /* ModernNetworkService.swift in Sources */,
 				ECA425EA29262A80004DFDAF /* LoginCoordinator.swift in Sources */,
 				ECA425DE29253292004DFDAF /* CoordinatorCase.swift in Sources */,
 				BDF4346E2AB1900200FFAA45 /* SmokingAreaEntity.swift in Sources */,
@@ -1364,6 +1396,7 @@
 				BD4B550F292A29EC00ECFD04 /* SmokingAreaResponseModel.swift in Sources */,
 				ECA425F6292634C9004DFDAF /* LoginViewModel.swift in Sources */,
 				EC1562312A6D7D8200163875 /* LocationService.swift in Sources */,
+				6DCD47AF2D2E0E5F009FD6DF /* ModernNetworkError.swift in Sources */,
 				779672AF2A58034E003064A8 /* ASAuthorizationControllerProxy.swift in Sources */,
 				BD90E9E22976C4F800C7CB6B /* Networking.swift in Sources */,
 				BDE3EEB22A1D124300632662 /* OAuthService.swift in Sources */,
@@ -1383,6 +1416,7 @@
 				77F1D82229269CC800F31D0C /* UIColor + Extension.swift in Sources */,
 				77F1D82429269E1C00F31D0C /* UIView + Extension.swift in Sources */,
 				BD4E13652973DAC400AEA757 /* NetworkError.swift in Sources */,
+				6DCD47AD2D2E0E2E009FD6DF /* ModernHttpMethod.swift in Sources */,
 				77E70F462930951100F55CD7 /* UITextField + Extension.swift in Sources */,
 				BDC50ED6292A09BD002378C6 /* BaseView.swift in Sources */,
 				BD90E9DE2976C11E00C7CB6B /* FogAPI.swift in Sources */,
@@ -1395,9 +1429,11 @@
 				77D32D41292A0EDD006E6314 /* ViewModelType.swift in Sources */,
 				BD2D276B297D17E400984B97 /* UserAPI.swift in Sources */,
 				BD5D0D7F29F15E3A00190471 /* BottomViewType.swift in Sources */,
+				6DCD47B92D2E153C009FD6DF /* ModernURLRequestBuildable.swift in Sources */,
 				ECA425E2292532CA004DFDAF /* DefaultAppCoordinator.swift in Sources */,
 				ECA4252F29224DB8004DFDAF /* SceneDelegate.swift in Sources */,
 				BDB6E1F72A30511C00AE6228 /* NetworkConnectionView.swift in Sources */,
+				6DCD47C42D2E4340009FD6DF /* JSONResponseDecoder.swift in Sources */,
 				776502182954A3BA002BF7AD /* SettingTitleTableViewCell.swift in Sources */,
 				ECA425EC29262CF8004DFDAF /* MapViewModel.swift in Sources */,
 				7761D4F4292F3471003971DC /* MakeNicknameViewController.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
+++ b/FogFog-iOS/FogFog-iOS.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1DDE6DAB87E9F15EAEAD8A1B /* Pods_FogFog_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44BDDCB91FAFFFC51A0C1A4C /* Pods_FogFog_iOS.framework */; };
 		35919B344F294722AA448E4E /* Pods_FogFog_iOS_FogFog_iOSUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D67B489E657987D4A7AD92C7 /* Pods_FogFog_iOS_FogFog_iOSUITests.framework */; };
 		56E6DAD19F1058E2F6B779B7 /* Pods_FogFog_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848DD0928406FC10714344E4 /* Pods_FogFog_iOSTests.framework */; };
+		6D69A85A2D364949007B6538 /* ModernHTTPTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D69A8592D364943007B6538 /* ModernHTTPTask.swift */; };
 		6DCD47AD2D2E0E2E009FD6DF /* ModernHttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47AC2D2E0E18009FD6DF /* ModernHttpMethod.swift */; };
 		6DCD47AF2D2E0E5F009FD6DF /* ModernNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47AE2D2E0E59009FD6DF /* ModernNetworkError.swift */; };
 		6DCD47B72D2E1432009FD6DF /* ModernEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCD47B62D2E142E009FD6DF /* ModernEndpoint.swift */; };
@@ -177,6 +178,7 @@
 		44BDDCB91FAFFFC51A0C1A4C /* Pods_FogFog_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FogFog_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		47D49EE273F775CA2202B593 /* Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig"; path = "Target Support Files/Pods-FogFog-iOS-FogFog-iOSUITests/Pods-FogFog-iOS-FogFog-iOSUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		568E5A05A08D8D049D3D8E62 /* Pods-FogFog-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FogFog-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-FogFog-iOSTests/Pods-FogFog-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		6D69A8592D364943007B6538 /* ModernHTTPTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernHTTPTask.swift; sourceTree = "<group>"; };
 		6DCD47AC2D2E0E18009FD6DF /* ModernHttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernHttpMethod.swift; sourceTree = "<group>"; };
 		6DCD47AE2D2E0E59009FD6DF /* ModernNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernNetworkError.swift; sourceTree = "<group>"; };
 		6DCD47B62D2E142E009FD6DF /* ModernEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernEndpoint.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 				6DCD47AC2D2E0E18009FD6DF /* ModernHttpMethod.swift */,
 				6DCD47AE2D2E0E59009FD6DF /* ModernNetworkError.swift */,
 				6DCD47B62D2E142E009FD6DF /* ModernEndpoint.swift */,
+				6D69A8592D364943007B6538 /* ModernHTTPTask.swift */,
 				6DCD47B82D2E152C009FD6DF /* ModernURLRequestBuildable.swift */,
 				6DCD47C12D2E42CB009FD6DF /* ModernNetworkSession.swift */,
 				6DCD47C32D2E432F009FD6DF /* JSONResponseDecoder.swift */,
@@ -1420,6 +1423,7 @@
 				77E70F462930951100F55CD7 /* UITextField + Extension.swift in Sources */,
 				BDC50ED6292A09BD002378C6 /* BaseView.swift in Sources */,
 				BD90E9DE2976C11E00C7CB6B /* FogAPI.swift in Sources */,
+				6D69A85A2D364949007B6538 /* ModernHTTPTask.swift in Sources */,
 				BD5D0D7029F12E0600190471 /* MessageModel.swift in Sources */,
 				BD347C5E292FD2BE009F52BA /* FogButtonStyle.swift in Sources */,
 				ECA4259B2922A4A6004DFDAF /* FogImage.swift in Sources */,

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/JSONResponseDecoder.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/JSONResponseDecoder.swift
@@ -1,0 +1,28 @@
+//
+//  JSONResponseDecoder.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import Foundation
+
+/// 데이터 디코딩을 위한 프로토콜
+/// - Note: 데이터 디코딩 추상화
+protocol ResponseDecoding {
+   func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T
+}
+
+/// JSON 데이터 디코딩을 담당하는 구조체
+/// - Note: ResponseDecoding 프로토콜 기본 구현체
+struct JSONResponseDecoder: ResponseDecoding {
+   private let decoder: JSONDecoder
+   
+   init(decoder: JSONDecoder = JSONDecoder()) {
+       self.decoder = decoder
+   }
+   
+   func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+       try decoder.decode(type, from: data)
+   }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernEndpoint.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernEndpoint.swift
@@ -1,0 +1,15 @@
+//
+//  ModernEndpoint.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import Foundation
+
+protocol ModernEndpoint {
+    var path: String { get }
+    var method: ModernHttpMethod { get }
+    var parameters: [String: Any]? { get }
+    var headers: [String: String]? { get }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernEndpoint.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernEndpoint.swift
@@ -10,6 +10,6 @@ import Foundation
 protocol ModernEndpoint {
     var path: String { get }
     var method: ModernHttpMethod { get }
-    var parameters: [String: Any]? { get }
+    var task: ModernHTTPTask { get }
     var headers: [String: String]? { get }
 }

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernHTTPTask.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernHTTPTask.swift
@@ -1,0 +1,15 @@
+//
+//  ModernHTTPTask.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/14/25.
+//
+
+import Foundation
+
+enum ModernHTTPTask {
+    case query(_ query: [String: Any])
+    case queryBody(_ query: [String: Any], _ body: [String: Any])
+    case requestBody(_ body: [String: Any])
+    case requestPlain
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernHttpMethod.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernHttpMethod.swift
@@ -1,0 +1,15 @@
+//
+//  ModernHttpMethod.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import Foundation
+
+enum ModernHttpMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernHttpStatusCode.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernHttpStatusCode.swift
@@ -1,0 +1,57 @@
+//
+//  ModernHttpStatusCode.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+/// ModernNetworkError의 HTTP 상태 코드를 정의하고 관리
+/// - Note: 서버 응답의 상태 코드에 따른 NetworkError 생성
+/// - Author: seungchan
+public enum ModernHTTPStatusCode: Int {
+   /// 400: 잘못된 요청 (Bad Request)
+   /// - 클라이언트의 요청이 유효하지 않은 경우
+   case invalidRequest = 400
+   
+   /// 401: 인증 실패 (Unauthorized)
+   /// - 소셜 로그인 토큰이 없거나 유효하지 않은 경우
+   case unauthorized = 401
+   
+   /// 403: 접근 권한 없음 (Forbidden)
+   /// - 요청 id와 accessToken 정보가 매칭되지 않는 경우
+   case forbidden = 403
+   
+   /// 404: 리소스를 찾을 수 없음 (Not Found)
+   /// - 유효한 유저 정보가 없는 경우
+   case notFound = 404
+   
+   /// 409: 리소스 충돌 (Conflict)
+   /// - 중복된 닉네임일 경우
+   case duplicated = 409
+   
+   /// 500: 서버 내부 오류 (Internal Server Error)
+   /// - 서버에서 처리 중 예기치 않은 오류가 발생한 경우
+   case serverError = 500
+   
+   /// HTTP 상태 코드에 해당하는 NetworkError를 생성
+   /// - Parameter data: 서버로부터 받은 에러 응답 데이터
+   /// - Returns: 상태 코드와 에러 메시지를 포함한 NetworkError
+   public func createError(with data: Data) -> NetworkError {
+       let message = getErrorMessage(from: data)
+       switch self {
+       case .invalidRequest: return .invalidRequest(message: message)
+       case .unauthorized: return .unauthorized(message: message)
+       case .forbidden: return .forbidden(message: message)
+       case .notFound: return .notFound(message: message)
+       case .duplicated: return .duplicated(message: message)
+       case .serverError: return .serverError(message: message)
+       }
+   }
+   
+   /// 서버 응답 데이터에서 에러 메시지를 추출
+   /// - Parameter data: 서버로부터 받은 에러 응답 데이터
+   /// - Returns: 에러 메시지 문자열. 디코딩 실패 시 nil 반환
+   private func getErrorMessage(from data: Data) -> String? {
+       try? JSONDecoder().decode(ErrorResponse.self, from: data).message
+   }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernNetworkError.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernNetworkError.swift
@@ -1,0 +1,93 @@
+//
+//  ModernNetworkError.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import Foundation
+
+/// 네트워크 작업 중 발생할 수 있는 에러를 정의하는 열거형
+/// - Note: HTTP 상태 코드 및 클라이언트 에러 처리
+public enum ModernNetworkError: Error {
+    /// - Parameters:
+    ///   - statusCode: HTTP 상태 코드
+    ///   - message: 서버에서 전달된 에러 메시지
+    case http(statusCode: Int, message: String?)
+    
+    /// 잘못된 URL 형식
+    case invalidURL
+    /// JSON 디코딩 실패
+    case decodingError(Error)
+    /// 요청 시간 초과
+    case timeout
+    /// 인터넷 연결 없음
+    case noInternetConnection
+    
+    struct ErrorResponse: Decodable {
+        let message: String
+    }
+}
+
+public extension ModernNetworkError {
+    /// 400 Bad Request 에러 생성
+    func invalidRequest(message: String? = nil) -> Self {
+        .http(statusCode: 400, message: message)
+    }
+    
+    /// 401 Unauthorized 에러 생성
+    func unauthorized(message: String? = nil) -> Self {
+        .http(statusCode: 401, message: message)
+    }
+    
+    /// 403 Forbidden 에러 생성
+    func forbidden(message: String? = nil) -> Self {
+        .http(statusCode: 403, message: message)
+    }
+    
+    /// 404 Not Found 에러 생성
+    func notFound(message: String? = nil) -> Self {
+        .http(statusCode: 404, message: message)
+    }
+    
+    /// 409 Conflict 에러 생성
+    func duplicated(message: String? = nil) -> Self {
+        .http(statusCode: 409, message: message)
+    }
+    
+    /// 500 Internal Server Error 생성
+    func serverError(message: String? = nil) -> Self {
+        .http(statusCode: 500, message: message)
+    }
+    
+    /// HTTP 상태 코드와 응답 데이터로부터 에러 생성
+    /// - Parameters:
+    ///   - statusCode: HTTP 상태 코드
+    ///   - data: 서버 응답 데이터
+    func from(statusCode: Int, data: Data) -> Self {
+        let message = try? JSONDecoder()
+            .decode(ErrorResponse.self, from: data)
+            .message
+        return .http(statusCode: statusCode, message: message)
+    }
+    
+    /// 에러 요약
+    var errorDescription: String {
+        switch self {
+        case .http(let statusCode, let message):
+            switch statusCode {
+            case 400: return message ?? "잘못된 요청입니다."
+            case 401: return message ?? "소셜 로그인 토큰이 유효하지 않습니다."
+            case 403: return message ?? "해당 요청에 대한 권한이 없습니다."
+            case 404: return message ?? "유효한 유저 정보가 없습니다."
+            case 409: return message ?? "중복된 닉네임입니다."
+            case 500: return message ?? "서버 내부 오류가 발생했습니다."
+            default: return message ?? "알 수 없는 오류가 발생했습니다. (Status: \(statusCode))"
+            }
+        case .invalidURL: return "유효하지 않은 URL입니다."
+        case .decodingError(let error): return "데이터 디코딩 실패: \(error.localizedDescription)"
+        case .timeout: return "요청 시간이 초과되었습니다."
+        case .noInternetConnection: return "인터넷 연결을 확인해주세요."
+        }
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernNetworkService.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernNetworkService.swift
@@ -1,0 +1,276 @@
+//
+//  ModernNetworkService.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import UIKit
+
+protocol Networking {
+    /// 기본 네트워크 요청 수행
+    func request<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type
+    ) async throws -> T
+    
+    /// 취소 가능한 네트워크 요청 수행
+    func cancellableRequest<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type
+    ) async -> AsyncThrowingStream<T, Error>
+    
+    /// 진행률을 포함한 네트워크 요청 수행
+    func requestWithProgress<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type
+    ) async -> AsyncThrowingStream<(T?, Double), Error>
+    
+    /// 재시도 네트워크 요청 수행
+    func requestWithRetry<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type,
+        maxRetries: Int
+    ) async throws -> T
+    
+    /// 타임아웃이 포함된 네트워크 요청 수행
+    func requestWithTimeout<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type,
+        timeout: TimeInterval
+    ) async throws -> T
+}
+
+/// 네트워크 요청을 처리하는 actor 클래스
+/// - Note: Thread-safe한 네트워크 작업을 위해 actor로 구현
+/// - Author: seungchan
+actor NetworkService: Networking {
+    // MARK: - Properties
+    /// 네트워크 세션을 관리
+    private let session: NetworkSession
+    /// HTTP 요청을 생성하는 빌더
+    private let requestBuilder: ModernURLRequestBuildable
+    /// 응답 데이터를 디코딩하는 인스턴스
+    private let responseDecoder: ResponseDecoding
+    /// 현재 활성화된 요청들을 저장하는 딕셔너리
+    private var activeRequests: [String: Task<Any, Error>] = [:]
+    
+    // MARK: - Initialization
+    /// - Parameters:
+    ///   - session: 네트워크 세션 (기본값: URLSession.shared)
+    ///   - requestBuilder: HTTP 요청 빌더 (기본값: URLRequestBuilder())
+    ///   - responseDecoder: 응답 디코더 (기본값: JSONResponseDecoder())
+    init(
+        session: NetworkSession = URLSession.shared,
+        requestBuilder: ModernURLRequestBuildable = ModernURLRequestBuilder(),
+        responseDecoder: ResponseDecoding = JSONResponseDecoder()
+    ) {
+        self.session = session
+        self.requestBuilder = requestBuilder
+        self.responseDecoder = responseDecoder
+    }
+    
+    // MARK: - Public Methods
+       
+    /// 기본 네트워크 요청 수행
+    /// - Parameters:
+    ///   - endpoint: 요청할 Endpoint
+    ///   - type: 응답 데이터를 디코딩할 타입
+    /// - Returns: 디코딩된 응답 데이터
+    /// - Throws: NetworkError
+    func request<T: Decodable>(
+        _ endpoint: Endpoint,
+        type: T.Type
+    ) async throws -> T {
+        let request = try requestBuilder.buildRequest(from: endpoint)
+        let (data, response) = try await session.data(for: request)
+        return try processResponse(data: data, response: response, type: type)
+    }
+    
+    /// 취소 가능한 네트워크 요청 수행
+    /// - Parameters:
+    ///   - endpoint: 요청할 Endpoint
+    ///   - type: 응답 데이터를 디코딩할 타입
+    /// - Returns: AsyncThrowingStream으로 래핑된 응답 데이터
+    func cancellableRequest<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type
+    ) -> AsyncThrowingStream<T, Error> {
+        AsyncThrowingStream { continuation in
+            let requestId = UUID().uuidString
+            
+            let task = Task<Any, Error> {
+                do {
+                    let result = try await request(endpoint, type: type)
+                    continuation.yield(result)
+                    continuation.finish()
+                    return result
+                } catch {
+                    continuation.finish(throwing: error)
+                    throw error
+                }
+            }
+            
+            storeTask(task, for: requestId)
+            
+            continuation.onTermination = { [weak self] _ in
+                Task { [weak self] in
+                    await self?.removeTask(for: requestId)
+                }
+            }
+        }
+    }
+    
+    /// 진행률을 포함한 네트워크 요청 수행
+    /// - Parameters:
+    ///   - endpoint: 요청할 Endpoint
+    ///   - type: 응답 데이터를 디코딩할 타입
+    /// - Returns: 진행률과 함께 응답 데이터를 스트림으로 반환
+    func requestWithProgress<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type
+    ) -> AsyncThrowingStream<(T?, Double), Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let request = try requestBuilder.buildRequest(from: endpoint)
+                    let (bytes, response) = try await session.bytes(for: request)
+                    
+                    guard let httpResponse = response as? HTTPURLResponse,
+                          httpResponse.expectedContentLength > 0 else {
+                        throw NetworkError.invalidURL
+                    }
+                    
+                    let expectedLength = httpResponse.expectedContentLength
+                    var accumulated = Data()
+                    var lastReportedProgress: Int = -1
+                    
+                    for try await byte in bytes {
+                        accumulated.append(byte)
+                        let progress = Double(accumulated.count) / Double(expectedLength)
+                        let roundedProgress = Int(progress * 100)
+                        
+                        if roundedProgress != lastReportedProgress {
+                            lastReportedProgress = roundedProgress
+                            if accumulated.count == expectedLength {
+                                let result: T = try processResponse(
+                                    data: accumulated,
+                                    response: response,
+                                    type: type
+                                )
+                                continuation.yield((result, 1.0))
+                            } else {
+                                continuation.yield((nil, progress))
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+    
+    /// 재시도 네트워크 요청 수행
+    /// - Parameters:
+    ///   - endpoint: 요청할 Endpoint
+    ///   - type: 응답 데이터를 디코딩할 타입
+    ///   - maxRetries: 최대 재시도 횟수
+    /// - Returns: 디코딩된 응답 데이터
+    /// - Throws: NetworkError
+    func requestWithRetry<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type,
+        maxRetries: Int
+    ) async throws -> T {
+        var remainingAttempts = maxRetries
+        var lastError: Error?
+        
+        repeat {
+            do {
+                return try await request(endpoint, type: type)
+            } catch {
+                lastError = error
+                remainingAttempts -= 1
+                
+                if remainingAttempts > 0 {
+                    try await Task.sleep(nanoseconds: calculateBackoff(attempt: maxRetries - remainingAttempts))
+                }
+            }
+        } while remainingAttempts > 0
+        
+        throw lastError ?? NetworkError.invalidURL
+    }
+    
+    /// 타임아웃이 포함된 네트워크 요청 수행
+    /// - Parameters:
+    ///   - endpoint: 요청할 Endpoint
+    ///   - type: 응답 데이터를 디코딩할 타입
+    ///   - timeout: 타임아웃 시간 (초)
+    /// - Returns: 디코딩된 응답 데이터
+    func requestWithTimeout<T: Decodable>(
+        _ endpoint: ModernEndpoint,
+        type: T.Type,
+        timeout: TimeInterval
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await self.request(endpoint, type: type)
+            }
+            
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw NetworkError.invalidURL
+            }
+            
+            for try await result in group {
+                group.cancelAll()
+                return result
+            }
+            
+            throw NetworkError.invalidRequest
+        }
+    }
+    
+    // MARK: - Private Methods
+    /// HTTP 응답을 처리 및 데이터 디코딩
+    private func processResponse<T: Decodable>(
+        data: Data,
+        response: URLResponse,
+        type: T.Type
+    ) throws -> T {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.http(statusCode: 0, message: "Invalid HTTP response")
+        }
+        
+        if (200...299).contains(httpResponse.statusCode) {
+            do {
+                return try responseDecoder.decode(type, from: data)
+            } catch {
+                throw NetworkError.decodingError(error)
+            }
+        }
+        
+        throw NetworkError.from(statusCode: httpResponse.statusCode, data: data)
+    }
+    
+    /// 재시도 간격을 계산
+    private func calculateBackoff(attempt: Int) -> UInt64 {
+        let baseDelay: UInt64 = 1_000_000_000
+        let maxDelay: UInt64 = 10_000_000_000
+        let delay = baseDelay * UInt64(pow(2.0, Double(attempt)))
+        return min(delay, maxDelay)
+    }
+    
+    /// 활성 요청을 저장
+    private func storeTask(_ task: Task<Any, Error>, for identifier: String) {
+        activeRequests[identifier] = task
+    }
+    
+    /// 활성 요청을 제거하고 취소
+    private func removeTask(for identifier: String) {
+        activeRequests[identifier]?.cancel()
+        activeRequests.removeValue(forKey: identifier)
+    }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernNetworkSession.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernNetworkSession.swift
@@ -1,0 +1,30 @@
+//
+//  ModernNetworkSession.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import UIKit
+
+/// 네트워크 세션 동작을 정의하는 프로토콜
+/// - Note: URLSession의 주요 네트워킹 기능을 추상화  정의
+/// 
+protocol NetworkSession {
+   /// 데이터 요청 수행 및 응답 반환
+   func data(for request: URLRequest) async throws -> (Data, URLResponse)
+   
+   /// 스트림 형태의 바이트 데이터 요청 수행
+   func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse)
+}
+
+extension URLSession: NetworkSession {
+   func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+       try await data(for: request, delegate: nil)
+   }
+    
+   @available(iOS 15.0, *)
+   func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse) {
+       try await bytes(for: request, delegate: nil)
+   }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernURLRequestBuildable.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernURLRequestBuildable.swift
@@ -1,0 +1,37 @@
+//
+//  ModernURLRequestBuildable.swift
+//  FogFog-iOS
+//
+//  Created by MEGA_Mac on 1/8/25.
+//
+
+import UIKit
+
+/// URL 요청 생성을 위한 프로토콜
+/// - Note: endpoint 기반으로 URLRequest를 생성하는 프로토콜
+protocol ModernURLRequestBuildable {
+   /// endpoint로부터 URLRequest를 생성
+   func buildRequest(from endpoint: ModernEndpoint) throws -> URLRequest
+}
+
+/// URLRequest 생성을 담당하는 구조체
+/// - Note: ModernURLRequestBuildable 프로토콜 기본 구현체
+struct ModernURLRequestBuilder: ModernURLRequestBuildable {
+   func buildRequest(from endpoint: ModernEndpoint) throws -> URLRequest {
+       // baseURL + path
+       let url = URL(string: NetworkEnv.baseURL)!.appendingPathComponent(endpoint.path)
+       var request = URLRequest(url: url)
+       request.httpMethod = endpoint.method.rawValue
+       
+       // header
+       endpoint.headers?.forEach { request.addValue($1, forHTTPHeaderField: $0) }
+       
+       // HTTP 메서드가 GET이 아닌 경우, 파라미터를 JSON 형태로 변환하여 body에 추가
+       if let parameters = endpoint.parameters, endpoint.method != .get {
+           request.httpBody = try JSONSerialization.data(withJSONObject: parameters)
+           request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+       }
+       
+       return request
+   }
+}

--- a/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernURLRequestBuildable.swift
+++ b/FogFog-iOS/FogFog-iOS/ModernNetwork/ModernURLRequestBuildable.swift
@@ -27,11 +27,27 @@ struct ModernURLRequestBuilder: ModernURLRequestBuildable {
        endpoint.headers?.forEach { request.addValue($1, forHTTPHeaderField: $0) }
        
        // HTTP 메서드가 GET이 아닌 경우, 파라미터를 JSON 형태로 변환하여 body에 추가
-       if let parameters = endpoint.parameters, endpoint.method != .get {
-           request.httpBody = try JSONSerialization.data(withJSONObject: parameters)
-           request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-       }
-       
-       return request
+       switch endpoint.task {
+        case .query(let query):
+            let queryParams = query.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+           var components = URLComponents(string: url.appendingPathComponent(endpoint.path).absoluteString)
+            components?.queryItems = queryParams
+            request.url = components?.url
+            
+        case .queryBody(let query, let body):
+            let queryParams = query.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+            var components = URLComponents(string: url.appendingPathComponent(endpoint.path).absoluteString)
+            components?.queryItems = queryParams
+            request.url = components?.url
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+            
+        case .requestBody(let body):
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+            
+        case .requestPlain:
+            break
+        }
+        
+        return request
    }
 }


### PR DESCRIPTION
## 🔍 What is this PR?
- RxMoya 코드를 Concurrency로 리팩토링 진행하였습니다.
- 여러 부분을 개선아닌 개선을 진행하면서 자세히 봐야하는 부분 먼저 말씀드리겠습니다 ㅎㅎ.. 좋은 방법있으면 더 말씀해주세요 :) 

## 📝 Changes
### 1. URLSession -> 프로토콜 기반 설계
- RxSwift 기반 네트워크 코드를 URLSession으로 바꾸면서 모든 코드가 한 곳에 모여 역할 분리가 되지 않는다는 문제점을 고민했습니다.
- 아래는 URLSession의 일반적인 코드입니다. 
 ```swift
 func fetchData() {
        let url = URL(string: "테스트")!
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
        1. 에러 처리
        guard error == nil else { 
            return 
        }
        
        // 2. 응답 처리
        guard let httpResponse = response as? HTTPURLResponse,
              (200...299).contains(httpResponse.statusCode) else {
            상태 코드 처리
            return
        }
        
        3. 데이터 파싱
        do {
            let result = try JSONDecoder().decode(Response.self, from: data!)
            성공 처리
        } catch {
            디코딩 에러 처리
        }
    }
    task.resume()
    }
 ```
 ```swift
 func request<T: Decodable>(
        _ endpoint: Endpoint,
        type: T.Type
    ) async throws -> T {
        let request = try requestBuilder.buildRequest(from: endpoint)
        let (data, response) = try await session.data(for: request)
        return try processResponse(data: data, response: response, type: type)
    }
 ```
- 하나의 메서드에서 너무 많은 역할을 수행하고, 테스트가 어렵다는 문제점이 있었습니다.
- 그래서 네트워크 통신, 응답 처리, 요청 생성 부분을 추상화했습니다. `NetworkSession` `ResponseDecoding` `ModernURLRequestBuildable`
- 해당 구조의 장점은 일단 독립적인 테스트가 가능하고, 각 역할이 명확하게 분리되는 것 같습니다. (마이그레이션 하면서 와닿을 것 같습니다..!)

### 2. 여러 시나리오를 고려한 네트워크 메소드 설계
- `ModernNetworkService.swift` 파일을 보면 Networking 프로토콜 안에 5개의 메소드가 있습니다.
- 여러가지 네트워크 시나리오에 따라서 다음과 같이 나눴습니다.
  1. 기본 네트워크 요청 수행
  2. 취소 가능한 네트워크 요청 수행
  3. 진행률을 포함한 네트워크 요청 수행
  4. 재시도 네트워크 요청 수행
  5. 타임아웃이 필요한 네트워크 요청 수행
 
- 기본 네트워크는 `request` 메소드를 사용하면 되고, 취소 가능한 네트워크 요청은 Concurrency가 GCD 코드보다 취소에 장점이 있어 사용자가 네트워크 통신 중, 이탈하는 경우 등 다양한 엣지 케이스를 고려하여 일단 ㅎㅎ.. 5가지를 만들어 뒀습니다!
- 내부 코드는 온라인 / 오프라인에서 설명드릴게요!

### 3. 에러 상태 정립 필요
- 2년만에 다시 하려고 하니까 헷갈려요 .. 
- 일단 기존 코드 참고해서 에러 코드를 세분화했습니다.
- 기존에는 열거형이 Int 타입으로, 에러 처리를 따로 해줬어야 했는데 지금은 Error를 채택해서 한번에 처리해주는 방법으로 수정해뒀습니다.
- 좋은 의견 있으면 말씀주십시오.

### 4. actor를 사용한 네트워크 구현
- 짧은 시간 내 여러 번의 네트워크 호출, 한 화면에 여러 API 사용, 취소나 타임아웃 처리 시 발생할 수 있는 Data race를 피하기 위해 actor로 구현했습니다.
- actor 관련 WWDC 첨부했습니다요!
https://developer.apple.com/videos/play/wwdc2021/10133/

### 5. 사용법
- 기존 Moya 사용할 때와 비슷하게 사용하시면 됩니다!
- 다만 문제점이 있다면 return값에 Observable 방출을 해야해서,, onNext를 통해서 방출하거나 아예 Rx를 걷어내는 것도 .. 좋은 방법일수도 ... 다음 이슈에서 기존 API 수정해둘겝쇼
 ```swift
    let task = Task {
             do {
                 let response = try await self.networkClient.request(
                EndPoint.fetch,
                type: Response.self
    )
}
 ```

<img width="1149" alt="스크린샷 2025-01-08 오후 3 27 40" src="https://github.com/user-attachments/assets/a85c8782-555a-4526-baac-0e609e81b254" />

## 📮 관련 이슈
- Resolved: #84
